### PR TITLE
added false positive test case for AK1000

### DIFF
--- a/akka.analyzers.sln.DotSettings
+++ b/akka.analyzers.sln.DotSettings
@@ -4,4 +4,5 @@
      Copyright (C) 2009-${CurrentDate.Year} Lightbend Inc. &amp;lt;http://www.lightbend.com&amp;gt;&amp;#xD;
      Copyright (C) 2013-${CurrentDate.Year} .NET Foundation &amp;lt;https://github.com/akkadotnet/akka.net&amp;gt;&amp;#xD;
  &amp;lt;/copyright&amp;gt;&amp;#xD;
------------------------------------------------------------------------</s:String></wpf:ResourceDictionary>
+-----------------------------------------------------------------------</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EFeature_002EServices_002ECodeCleanup_002EFileHeader_002EFileHeaderSettingsMigrate/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Akka.Analyzers.Tests/Analyzers/AK1000/MustNotUseNewKeywordOnActorsAnalyzerSpecs.cs
+++ b/src/Akka.Analyzers.Tests/Analyzers/AK1000/MustNotUseNewKeywordOnActorsAnalyzerSpecs.cs
@@ -73,6 +73,62 @@ public class MustNotUseNewKeywordOnActorsAnalyzerSpecs
                 IActorRef realActorInstance = sys.ActorOf(props);
             }
         }
+        """,
+        
+        // ReceiveActor with CTOR arguments
+        """
+        using Akka.Actor;
+        
+        class MyActor : ReceiveActor {
+            private readonly string _name;
+            private readonly int _myVar;
+        
+            public MyActor(string name, int myVar){
+                _name = name;
+                _myVar = myVar;
+                ReceiveAny(_ => {
+                    Sender.Tell(_name + _myVar);
+                });
+            }
+        }
+        
+        class Test
+        {
+            void Method()
+            {
+                ActorSystem sys = ActorSystem.Create("MySys");
+                Props props = Props.Create(() => new MyActor("foo", 1));
+                IActorRef realActorInstance = sys.ActorOf(props);
+            }
+        }
+        """,
+        
+        // ReceiveActor with explicit Akka.Actor.Props invocation (found this in real-world use)
+        """
+        using Akka.Actor;
+
+        class MyActor : ReceiveActor {
+            private readonly string _name;
+            private readonly int _myVar;
+        
+            public MyActor(string name, int myVar){
+                _name = name;
+                _myVar = myVar;
+                ReceiveAny(_ => {
+                    Sender.Tell(_name + _myVar);
+                });
+            }
+        }
+
+        class Test
+        {
+            void Method()
+            {
+                ActorSystem sys = ActorSystem.Create("MySys");
+                Akka.Actor.Props props = Akka.Actor.Props.Create(() => new MyActor("foo", 1));
+                IActorRef realActorInstance = sys.ActorOf(props);
+            }
+        }
         """
     };
 


### PR DESCRIPTION
Issue here is that we're only checking lexical equality, not symbol equality - hence why calls to `Akka.Actor.Props.Create` get falsely flagged.