### PR TITLE
AK1000: added failing test case for `IIndirectActorProducer.Produce`

### DIFF
--- a/src/Akka.Analyzers.Tests/Analyzers/AK1000/MustNotUseNewKeywordOnActorsAnalyzerSpecs.cs
+++ b/src/Akka.Analyzers.Tests/Analyzers/AK1000/MustNotUseNewKeywordOnActorsAnalyzerSpecs.cs
@@ -167,6 +167,43 @@ public class MustNotUseNewKeywordOnActorsAnalyzerSpecs
                 return Method(() => new MyActor("foo", 1));
             }
         }
+        """,
+        
+        // IIndirectActorProducer - won't often be found in user code, but should be supported
+        """
+        using Akka.Actor;
+        using System;
+        
+        public class TestProducer : IIndirectActorProducer
+        {
+            public TestProducer()
+            {
+            }
+
+            public ActorBase Produce()
+            {
+                return new PropsTestActor();
+            }
+
+            public Type ActorType
+            {
+                get { return typeof(PropsTestActor); }
+            }
+
+
+            public void Release(ActorBase actor)
+            {
+                actor = null;
+            }
+        }
+
+        public class PropsTestActor : ActorBase
+        {
+            protected override bool Receive(object message)
+            {
+                return true;
+            }
+        }
         """
     };
 

--- a/src/Akka.Analyzers/Utility/AkkaCoreContext.cs
+++ b/src/Akka.Analyzers/Utility/AkkaCoreContext.cs
@@ -21,6 +21,10 @@ public interface IAkkaCoreContext
     public INamedTypeSymbol? ActorBaseType { get; }
     public INamedTypeSymbol? ActorRefType { get; }
     public INamedTypeSymbol? PropsType { get; }
+    
+    public INamedTypeSymbol? ActorContextType { get; }
+    
+    public INamedTypeSymbol? IndirectActorProducerType { get; }
 }
 
 /// <summary>
@@ -38,6 +42,10 @@ public sealed class EmptyCoreContext : IAkkaCoreContext
     public INamedTypeSymbol? ActorBaseType => null;
     public INamedTypeSymbol? ActorRefType => null;
     public INamedTypeSymbol? PropsType => null;
+    
+    public INamedTypeSymbol? ActorContextType => null;
+    
+    public INamedTypeSymbol? IndirectActorProducerType => null;
 }
 
 /// <summary>
@@ -52,6 +60,8 @@ public class AkkaCoreContext : IAkkaCoreContext
     private readonly Lazy<INamedTypeSymbol?> _lazyActorBaseType;
     private readonly Lazy<INamedTypeSymbol?> _lazyActorRefType;
     private readonly Lazy<INamedTypeSymbol?> _lazyPropsType;
+    private readonly Lazy<INamedTypeSymbol?> _lazyActorContextType;
+    private readonly Lazy<INamedTypeSymbol?> _lazyIIndirectActorProducerType;
 
     private AkkaCoreContext(Compilation compilation, Version version)
     {
@@ -59,6 +69,8 @@ public class AkkaCoreContext : IAkkaCoreContext
         _lazyActorBaseType = new Lazy<INamedTypeSymbol?>(() => TypeSymbolFactory.ActorBase(compilation));
         _lazyActorRefType = new Lazy<INamedTypeSymbol?>(() => TypeSymbolFactory.ActorReference(compilation));
         _lazyPropsType = new Lazy<INamedTypeSymbol?>(() => TypeSymbolFactory.Props(compilation));
+        _lazyActorContextType = new Lazy<INamedTypeSymbol?>(() => TypeSymbolFactory.ActorContext(compilation));
+        _lazyIIndirectActorProducerType = new Lazy<INamedTypeSymbol?>(() => TypeSymbolFactory.IndirectActorProducer(compilation));
     }
 
     /// <inheritdoc />
@@ -67,6 +79,10 @@ public class AkkaCoreContext : IAkkaCoreContext
     public INamedTypeSymbol? ActorBaseType => _lazyActorBaseType.Value;
     public INamedTypeSymbol? ActorRefType => _lazyActorRefType.Value;
     public INamedTypeSymbol? PropsType => _lazyPropsType.Value;
+    
+    public INamedTypeSymbol? ActorContextType => _lazyActorContextType.Value;
+    
+    public INamedTypeSymbol? IndirectActorProducerType => _lazyIIndirectActorProducerType.Value;
 
     public static AkkaCoreContext? Get(
         Compilation compilation,

--- a/src/Akka.Analyzers/Utility/TypeSymbolFactory.cs
+++ b/src/Akka.Analyzers/Utility/TypeSymbolFactory.cs
@@ -27,4 +27,16 @@ public static class TypeSymbolFactory
         return Guard.AssertIsNotNull(compilation)
             .GetTypeByMetadataName("Akka.Actor.Props");
     }
+    
+    public static INamedTypeSymbol? ActorContext(Compilation compilation)
+    {
+        return Guard.AssertIsNotNull(compilation)
+            .GetTypeByMetadataName("Akka.Actor.IActorContext");
+    }
+    
+    public static INamedTypeSymbol? IndirectActorProducer(Compilation compilation)
+    {
+        return Guard.AssertIsNotNull(compilation)
+            .GetTypeByMetadataName("Akka.Actor.IIndirectActorProducer");
+    }
 }


### PR DESCRIPTION
## Changes

AK1000 needs to be able to support [`IIndirecActorProducer`](https://getakka.net/api/Akka.Actor.IIndirectActorProducer.html).
