### PR TITLE
Fix `PipeTo` code fixes

### DIFF
--- a/src/Akka.Analyzers.Fixes/AK1000/MustCloseOverSenderWhenUsingPipeToFixer.cs
+++ b/src/Akka.Analyzers.Fixes/AK1000/MustCloseOverSenderWhenUsingPipeToFixer.cs
@@ -77,7 +77,7 @@ public sealed class MustCloseOverSenderWhenUsingPipeToFixer()
         var newRecipientArgument = SyntaxFactory.Argument(SyntaxFactory.IdentifierName("sender"));
 
         // Building a new list of arguments
-        var newArguments = SyntaxFactory.SeparatedList<ArgumentSyntax>(arguments.Select(arg =>
+        var newArguments = SyntaxFactory.SeparatedList(arguments.Select(arg =>
         {
             // Check if the argument is 'this.Sender'
             if (arg.Expression is IdentifierNameSyntax { Identifier.ValueText: "Sender" })

--- a/src/Akka.Analyzers.Fixes/AK1000/MustCloseOverSenderWhenUsingPipeToFixer.cs
+++ b/src/Akka.Analyzers.Fixes/AK1000/MustCloseOverSenderWhenUsingPipeToFixer.cs
@@ -70,13 +70,26 @@ public sealed class MustCloseOverSenderWhenUsingPipeToFixer()
         // Insert the local variable declaration at the found insertion point
         editor.InsertBefore(insertionPoint, senderVariable);
 
-        // in the invocationExpr, replace the old argument list with a new one that uses the new local variable
-        // Replace the invocation arguments with the new local variable
-        var newArgumentList = SyntaxFactory.ArgumentList(
-            SyntaxFactory.SingletonSeparatedList(
-                SyntaxFactory.Argument(
-                    SyntaxFactory.IdentifierName("sender"))));
+        // Identify the 'recipient' argument - assuming it's the first argument
+        var arguments = invocationExpr.ArgumentList.Arguments;
 
+        // Create a new argument to replace the 'recipient' argument
+        var newRecipientArgument = SyntaxFactory.Argument(SyntaxFactory.IdentifierName("sender"));
+
+        // Building a new list of arguments
+        var newArguments = SyntaxFactory.SeparatedList<ArgumentSyntax>(arguments.Select(arg =>
+        {
+            // Check if the argument is 'this.Sender'
+            if (arg.Expression is IdentifierNameSyntax { Identifier.ValueText: "Sender" })
+            {
+                return newRecipientArgument;
+            }
+
+            // For all other arguments, keep them as-is
+            return arg;
+        }));
+
+        var newArgumentList = SyntaxFactory.ArgumentList(newArguments);
         var newInvocationExpr = invocationExpr.WithArgumentList(newArgumentList);
 
         // Make sure to replace the old invocation with the new one

--- a/src/Akka.Analyzers.Tests/Analyzers/AK1000/MustCloseOverSenderWhenUsingPipeToAnalyzerSpecs.cs
+++ b/src/Akka.Analyzers.Tests/Analyzers/AK1000/MustCloseOverSenderWhenUsingPipeToAnalyzerSpecs.cs
@@ -135,7 +135,24 @@ public class MustCloseOverSenderWhenUsingPipeToAnalyzerSpecs
                 // incorrect use of closure
                 LocalFunction().PipeTo(Sender); 
             }
-        }", (13, 33, 13, 39))
+        }", (13, 33, 13, 39)),
+
+            // Actor is using Sender as the "sender" property on PipeTo, rather than the recipient
+            (@"using Akka.Actor;
+        using System.Threading.Tasks;
+
+        public sealed class MyActor : UntypedActor{
+
+            protected override void OnReceive(object message){
+                async Task<int> LocalFunction(){
+                    await Task.Delay(10);
+                    return message.ToString().Length;
+                }
+
+                // incorrect use of closure
+                LocalFunction().PipeTo(Self, Sender); 
+            }
+        }", (13, 33, 13, 39)),
         };
 
     [Theory]

--- a/src/Akka.Analyzers.Tests/Fixes/AK1000/MustCloseOverSenderWhenUsingPipeToFixerSpecs.cs
+++ b/src/Akka.Analyzers.Tests/Fixes/AK1000/MustCloseOverSenderWhenUsingPipeToFixerSpecs.cs
@@ -110,4 +110,54 @@ public sealed class MyActor : UntypedActor{
         return Verify.VerifyCodeFix(before, after, MustCloseOverSenderWhenUsingPipeToFixer.Key_FixPipeToSender,
             expectedDiagnostic);
     }
+
+    [Fact]
+    public Task AddClosureWithoutErasingOtherPipeToArguments()
+    {
+        var before =
+            @"using Akka.Actor;
+using System.Threading.Tasks;
+using System;
+
+public sealed class MyActor : UntypedActor{
+
+    protected override void OnReceive(object message){
+        async Task<int> LocalFunction(){
+            await Task.Delay(10);
+            return message.ToString().Length;
+        }
+
+        Console.WriteLine(Sender);
+        // incorrect use of closure
+        LocalFunction().PipeTo(Sender, success: r => 1); 
+    }
+}";
+
+        var after =
+            @"using Akka.Actor;
+using System.Threading.Tasks;
+using System;
+
+public sealed class MyActor : UntypedActor{
+
+    protected override void OnReceive(object message){
+        async Task<int> LocalFunction(){
+            await Task.Delay(10);
+            return message.ToString().Length;
+        }
+
+        Console.WriteLine(Sender);
+        var sender = this.Sender;
+        // incorrect use of closure
+        LocalFunction().PipeTo(sender, success: r => 1); 
+    }
+}";
+
+        var expectedDiagnostic = Verify.Diagnostic()
+            .WithSpan(15, 25, 15, 31)
+            .WithArguments("Sender");
+
+        return Verify.VerifyCodeFix(before, after, MustCloseOverSenderWhenUsingPipeToFixer.Key_FixPipeToSender,
+            expectedDiagnostic);
+    }
 }

--- a/src/Akka.Analyzers.Tests/Fixes/AK1000/MustCloseOverSenderWhenUsingPipeToFixerSpecs.cs
+++ b/src/Akka.Analyzers.Tests/Fixes/AK1000/MustCloseOverSenderWhenUsingPipeToFixerSpecs.cs
@@ -210,4 +210,54 @@ public sealed class MyActor : UntypedActor{
         return Verify.VerifyCodeFix(before, after, MustCloseOverSenderWhenUsingPipeToFixer.Key_FixPipeToSender,
             expectedDiagnostic);
     }
+
+    [Fact]
+    public Task ReplaceSenderWhenUsedForBothRecipientAndSender()
+    {
+        var before =
+            @"using Akka.Actor;
+using System.Threading.Tasks;
+using System;
+
+public sealed class MyActor : UntypedActor{
+
+    protected override void OnReceive(object message){
+        async Task<int> LocalFunction(){
+            await Task.Delay(10);
+            return message.ToString().Length;
+        }
+
+        Console.WriteLine(Sender);
+        // incorrect use of closure
+        LocalFunction().PipeTo(Sender, Sender); 
+    }
+}";
+
+        var after =
+            @"using Akka.Actor;
+using System.Threading.Tasks;
+using System;
+
+public sealed class MyActor : UntypedActor{
+
+    protected override void OnReceive(object message){
+        async Task<int> LocalFunction(){
+            await Task.Delay(10);
+            return message.ToString().Length;
+        }
+
+        Console.WriteLine(Sender);
+        var sender = this.Sender;
+        // incorrect use of closure
+        LocalFunction().PipeTo(sender, sender); 
+    }
+}";
+
+        var expectedDiagnostic = Verify.Diagnostic()
+            .WithSpan(15, 25, 15, 31)
+            .WithArguments("Sender");
+
+        return Verify.VerifyCodeFix(before, after, MustCloseOverSenderWhenUsingPipeToFixer.Key_FixPipeToSender,
+            expectedDiagnostic);
+    }
 }


### PR DESCRIPTION
Fixes #32

## Changes

Also, added checks to fix the `PipeTo`'s `sender` argument if that is set to `Sender` as well.
