### PR TITLE
`PipeTo` analyzer misses when the `this` keyword is used

### DIFF
--- a/src/Akka.Analyzers.Fixes/AK1000/MustCloseOverSenderWhenUsingPipeToFixer.cs
+++ b/src/Akka.Analyzers.Fixes/AK1000/MustCloseOverSenderWhenUsingPipeToFixer.cs
@@ -80,7 +80,8 @@ public sealed class MustCloseOverSenderWhenUsingPipeToFixer()
         var newArguments = SyntaxFactory.SeparatedList(arguments.Select(arg =>
         {
             // Check if the argument is 'this.Sender'
-            if (arg.Expression is IdentifierNameSyntax { Identifier.ValueText: "Sender" })
+            if (arg.Expression is IdentifierNameSyntax { Identifier.ValueText: "Sender" } or
+                MemberAccessExpressionSyntax { Name.Identifier.ValueText: "Sender" }) // need the right side of the "or" for `this.Sender"
             {
                 return newRecipientArgument;
             }

--- a/src/Akka.Analyzers.Tests/Analyzers/AK1000/MustCloseOverSenderWhenUsingPipeToAnalyzerSpecs.cs
+++ b/src/Akka.Analyzers.Tests/Analyzers/AK1000/MustCloseOverSenderWhenUsingPipeToAnalyzerSpecs.cs
@@ -153,6 +153,34 @@ public class MustCloseOverSenderWhenUsingPipeToAnalyzerSpecs
                 LocalFunction().PipeTo(Self, Sender); 
             }
         }", (13, 33, 13, 39)),
+
+            // Actor is using Sender as the "sender" property on PipeTo, rather than the recipient
+            ( // Actor is using this.Sender rather than just "Sender"
+                """
+                using Akka.Actor;
+                using System.Threading.Tasks;
+
+                public class MyActor
+                {
+                    public MyActor(IActorRef sender)
+                    {
+                        Sender = sender;
+                    }
+                
+                    public IActorRef Sender { get; }
+                    
+                    public void Method()
+                    {
+                        async Task<int> LocalFunction(){
+                           await Task.Delay(10);
+                           return 11;
+                       }
+                
+                        // Sender is immutable on this custom non-Actor class, so shouldn't flag this
+                        LocalFunction().PipeTo(this.Sender);
+                    }
+                }
+                """, (13, 33, 13, 39))
         };
 
     [Theory]

--- a/src/Akka.Analyzers.Tests/Analyzers/AK1000/MustCloseOverSenderWhenUsingPipeToAnalyzerSpecs.cs
+++ b/src/Akka.Analyzers.Tests/Analyzers/AK1000/MustCloseOverSenderWhenUsingPipeToAnalyzerSpecs.cs
@@ -159,28 +159,20 @@ public class MustCloseOverSenderWhenUsingPipeToAnalyzerSpecs
                 """
                 using Akka.Actor;
                 using System.Threading.Tasks;
-
-                public class MyActor
-                {
-                    public MyActor(IActorRef sender)
-                    {
-                        Sender = sender;
-                    }
                 
-                    public IActorRef Sender { get; }
-                    
-                    public void Method()
-                    {
+                public sealed class MyActor : UntypedActor{
+                
+                    protected override void OnReceive(object message){
                         async Task<int> LocalFunction(){
-                           await Task.Delay(10);
-                           return 11;
-                       }
+                            await Task.Delay(10);
+                            return message.ToString().Length;
+                        }
                 
-                        // Sender is immutable on this custom non-Actor class, so shouldn't flag this
-                        LocalFunction().PipeTo(this.Sender);
+                        // incorrect use of closure
+                        LocalFunction().PipeTo(this.Sender); 
                     }
                 }
-                """, (13, 33, 13, 39))
+                """, (13, 25, 13, 31))
         };
 
     [Theory]

--- a/src/Akka.Analyzers.Tests/Fixes/AK1000/MustCloseOverSenderWhenUsingPipeToFixerSpecs.cs
+++ b/src/Akka.Analyzers.Tests/Fixes/AK1000/MustCloseOverSenderWhenUsingPipeToFixerSpecs.cs
@@ -229,7 +229,7 @@ public sealed class MyActor : UntypedActor{
 
         Console.WriteLine(Sender);
         // incorrect use of closure
-        LocalFunction().PipeTo(Sender, Sender); 
+        LocalFunction().PipeTo(this.Sender, Sender); 
     }
 }";
 


### PR DESCRIPTION
## Changes

`PipeTo` analyzer misses when the `this` keyword is used - means that we're doing lexical equality and not symbolic equality (which is bad)