### PR TITLE
AK2001: test coverage for lambda case

### DIFF
--- a/src/Akka.Analyzers.Fixes/AK2000/MustNotUseAutomaticallyHandledMessagesInsideMessageExtractorFixer.cs
+++ b/src/Akka.Analyzers.Fixes/AK2000/MustNotUseAutomaticallyHandledMessagesInsideMessageExtractorFixer.cs
@@ -138,8 +138,10 @@ public class MustNotUseAutomaticallyHandledMessagesInsideMessageExtractorFixer()
         }
         else
         {
+            var leadingTrivia = forbiddenIfStatement.GetLeadingTrivia();
+            
             // If there's an else part, replace the if statement with the else part
-            return root.ReplaceNode(forbiddenIfStatement, forbiddenIfStatement.Else.Statement).WithLeadingTrivia();
+            return root.ReplaceNode(forbiddenIfStatement, forbiddenIfStatement.Else.Statement.WithLeadingTrivia(leadingTrivia));
         }
     }
 

--- a/src/Akka.Analyzers.Fixes/AK2000/MustNotUseAutomaticallyHandledMessagesInsideMessageExtractorFixer.cs
+++ b/src/Akka.Analyzers.Fixes/AK2000/MustNotUseAutomaticallyHandledMessagesInsideMessageExtractorFixer.cs
@@ -8,6 +8,7 @@ using System.Composition;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using IfStatementSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.IfStatementSyntax;

--- a/src/Akka.Analyzers.Fixes/AK2000/MustNotUseAutomaticallyHandledMessagesInsideMessageExtractorFixer.cs
+++ b/src/Akka.Analyzers.Fixes/AK2000/MustNotUseAutomaticallyHandledMessagesInsideMessageExtractorFixer.cs
@@ -18,11 +18,11 @@ namespace Akka.Analyzers.Fixes;
 
 [ExportCodeFixProvider(LanguageNames.CSharp)]
 [Shared]
-public class MustNotUseAutomaticallyHandledMessagesInsideMessageExtractorFixer()
+public class MustNotUseAutomaticallyHandledMessagesInsideMessageExtractorFixer() 
     : BatchedCodeFixProvider(RuleDescriptors.Ak2001DoNotUseAutomaticallyHandledMessagesInShardMessageExtractor.Id)
 {
     public const string Key_FixAutomaticallyHandledShardedMessage = "AK2001_FixAutoShardMessage";
-
+    
     public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
         var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
@@ -53,7 +53,7 @@ public class MustNotUseAutomaticallyHandledMessagesInsideMessageExtractorFixer()
             }
         }
     }
-
+    
     private static SyntaxNode? FindParentNodeToRemove(SyntaxNode? node)
     {
         while (node != null)
@@ -61,26 +61,23 @@ public class MustNotUseAutomaticallyHandledMessagesInsideMessageExtractorFixer()
             if (node is IfStatementSyntax || node is SwitchSectionSyntax || node is SwitchExpressionArmSyntax)
             {
                 // special case - have to check for else if here
-                if (node.Parent is ElseClauseSyntax)
+                if(node.Parent is ElseClauseSyntax)
                     return node.Parent;
                 return node;
             }
-
             node = node.Parent;
         }
-
         return null;
     }
 
-    private static async Task<Document> RemoveOffendingNode(Document document, SyntaxNode nodeToRemove,
-        CancellationToken cancellationToken)
+    private static async Task<Document> RemoveOffendingNode(Document document, SyntaxNode nodeToRemove, CancellationToken cancellationToken)
     {
         var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-        if (root == null)
+        if(root == null)
             return document;
 
         SyntaxNode? newRoot = null;
-
+        
         // check if this is an if statement we're removing
         if (nodeToRemove is IfStatementSyntax ifStatement)
         {
@@ -103,10 +100,10 @@ public class MustNotUseAutomaticallyHandledMessagesInsideMessageExtractorFixer()
         {
             newRoot = root.RemoveNode(nodeToRemove, SyntaxRemoveOptions.KeepNoTrivia);
         }
-
+        
         return newRoot == null ? document : document.WithSyntaxRoot(newRoot);
     }
-
+    
     private static SyntaxNode? RemoveForbiddenIfStatement(SyntaxNode root, IfStatementSyntax forbiddenIfStatement)
     {
         // Check if the if statement is part of an else-if chain
@@ -132,7 +129,7 @@ public class MustNotUseAutomaticallyHandledMessagesInsideMessageExtractorFixer()
                 }
             }
         }
-
+    
         // Handle removing a standalone if statement
         if (forbiddenIfStatement.Else == null)
         {
@@ -142,8 +139,8 @@ public class MustNotUseAutomaticallyHandledMessagesInsideMessageExtractorFixer()
         else
         {
             // If there's an else part, replace the if statement with the else part
-            return root.ReplaceNode(forbiddenIfStatement,
-                forbiddenIfStatement.Else.Statement.WithLeadingTrivia(forbiddenIfStatement.GetLeadingTrivia()));
+            return root.ReplaceNode(forbiddenIfStatement, forbiddenIfStatement.Else.Statement).WithLeadingTrivia();
         }
     }
+
 }

--- a/src/Akka.Analyzers.Fixes/AK2000/MustNotUseAutomaticallyHandledMessagesInsideMessageExtractorFixer.cs
+++ b/src/Akka.Analyzers.Fixes/AK2000/MustNotUseAutomaticallyHandledMessagesInsideMessageExtractorFixer.cs
@@ -138,6 +138,8 @@ public class MustNotUseAutomaticallyHandledMessagesInsideMessageExtractorFixer()
         }
         else
         {
+            // in order to get the replaced "if" statement to have the same indention as the other clauses, we need to re-use
+            // the same leading trivia that we had previously
             var leadingTrivia = forbiddenIfStatement.GetLeadingTrivia();
             
             // If there's an else part, replace the if statement with the else part

--- a/src/Akka.Analyzers.Fixes/AK2000/MustNotUseAutomaticallyHandledMessagesInsideMessageExtractorFixer.cs
+++ b/src/Akka.Analyzers.Fixes/AK2000/MustNotUseAutomaticallyHandledMessagesInsideMessageExtractorFixer.cs
@@ -119,13 +119,13 @@ public class MustNotUseAutomaticallyHandledMessagesInsideMessageExtractorFixer()
                     // Replace the current else-if with its own else
                     var newElseClause = elseClause.WithStatement(forbiddenIfStatement.Else.Statement);
                     var newParentIfStatement = parentIfStatement.WithElse(newElseClause);
-                    return root.ReplaceNode(parentIfStatement, newParentIfStatement);
+                    return root.ReplaceNode(parentIfStatement, newParentIfStatement).WithLeadingTrivia();
                 }
                 else
                 {
                     // Remove the else-if branch entirely
                     var newParentIfStatement = parentIfStatement.WithElse(null);
-                    return root.ReplaceNode(parentIfStatement, newParentIfStatement);
+                    return root.ReplaceNode(parentIfStatement, newParentIfStatement).WithLeadingTrivia();
                 }
             }
         }
@@ -139,7 +139,7 @@ public class MustNotUseAutomaticallyHandledMessagesInsideMessageExtractorFixer()
         else
         {
             // If there's an else part, replace the if statement with the else part
-            return root.ReplaceNode(forbiddenIfStatement, forbiddenIfStatement.Else.Statement);
+            return root.ReplaceNode(forbiddenIfStatement, forbiddenIfStatement.Else.Statement).WithLeadingTrivia();
         }
     }
 

--- a/src/Akka.Analyzers.Tests/Fixes/AK2000/MustNotHandleAutomaticallyHandledMessagesInMessageExtractorFixerSpecs.cs
+++ b/src/Akka.Analyzers.Tests/Fixes/AK2000/MustNotHandleAutomaticallyHandledMessagesInMessageExtractorFixerSpecs.cs
@@ -545,7 +545,7 @@ public sealed class ShardMessageExtractor : HashCodeMessageExtractor
                         IMessageExtractor Create(){
                            IMessageExtractor messageExtractor = HashCodeMessageExtractor.Create(100, msg =>
                            {
-                            	if (msg is string s) {
+                                if (msg is string s) {
                             		return s;
                             	}
                             	else {

--- a/src/Akka.Analyzers.Tests/Fixes/AK2000/MustNotHandleAutomaticallyHandledMessagesInMessageExtractorFixerSpecs.cs
+++ b/src/Akka.Analyzers.Tests/Fixes/AK2000/MustNotHandleAutomaticallyHandledMessagesInMessageExtractorFixerSpecs.cs
@@ -545,7 +545,7 @@ public sealed class ShardMessageExtractor : HashCodeMessageExtractor
                         IMessageExtractor Create(){
                            IMessageExtractor messageExtractor = HashCodeMessageExtractor.Create(100, msg =>
                            {
-                                if (msg is string s) {
+                            	if (msg is string s) {
                             		return s;
                             	}
                             	else {

--- a/src/Akka.Analyzers.Tests/Fixes/AK2000/MustNotHandleAutomaticallyHandledMessagesInMessageExtractorFixerSpecs.cs
+++ b/src/Akka.Analyzers.Tests/Fixes/AK2000/MustNotHandleAutomaticallyHandledMessagesInMessageExtractorFixerSpecs.cs
@@ -612,7 +612,7 @@ public sealed class ShardMessageExtractor : HashCodeMessageExtractor
                     """;
         
         var expectedDiagnostic = Verify.Diagnostic()
-            .WithSpan(10, 26, 10, 48);
+            .WithSpan(7, 23, 7, 45);
 
         return Verify.VerifyCodeFix(before, after, MustNotUseAutomaticallyHandledMessagesInsideMessageExtractorFixer.Key_FixAutomaticallyHandledShardedMessage,
             expectedDiagnostic);

--- a/src/Akka.Analyzers.Tests/Fixes/AK2000/MustNotHandleAutomaticallyHandledMessagesInMessageExtractorFixerSpecs.cs
+++ b/src/Akka.Analyzers.Tests/Fixes/AK2000/MustNotHandleAutomaticallyHandledMessagesInMessageExtractorFixerSpecs.cs
@@ -548,7 +548,7 @@ public sealed class ShardMessageExtractor : HashCodeMessageExtractor
                             	if (msg is string s) {
                             		return s;
                             	}
-                            	else{
+                            	else {
                             		return null;
                             	}
                             });

--- a/src/Akka.Analyzers.Tests/Fixes/AK2000/MustNotHandleAutomaticallyHandledMessagesInMessageExtractorFixerSpecs.cs
+++ b/src/Akka.Analyzers.Tests/Fixes/AK2000/MustNotHandleAutomaticallyHandledMessagesInMessageExtractorFixerSpecs.cs
@@ -576,14 +576,14 @@ public sealed class ShardMessageExtractor : HashCodeMessageExtractor
                             IMessageExtractor messageExtractor = HashCodeMessageExtractor.Create(100, msg =>
                             {
                                 if (msg is ShardingEnvelope shard) {
-                     	            return shard.EntityId;
+                                   return shard.EntityId;
                                 }
-                             	else if (msg is string s) {
-                             		return s;
-                             	}
-                             	else{
-                             		return null;
-                             	}
+                                else if (msg is string s) {
+                                    return s;
+                                }
+                                else{
+                                    return null;
+                                }
                              });
                          
                              return messageExtractor;
@@ -598,12 +598,12 @@ public sealed class ShardMessageExtractor : HashCodeMessageExtractor
                         IMessageExtractor Create(){
                            IMessageExtractor messageExtractor = HashCodeMessageExtractor.Create(100, msg =>
                            {
-                            	if (msg is string s) {
-                            		return s;
-                            	}
-                            	else{
-                            		return null;
-                            	}
+                               if (msg is string s) {
+                                   return s;
+                               }
+                               else{
+                                   return null;
+                               }
                             });
                         
                             return messageExtractor;


### PR DESCRIPTION
## Changes

Making sure that our `HashCodeMessageExtractor.Create`-based implementations can get CodeFix support as well.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).