### PR TITLE
Improve `GracefulStop()` analyzer and code fix

### DIFF
--- a/src/Akka.Analyzers.Tests/Analyzers/AK1000/MustNotAwaitGracefulStopInsideReceiveAsyncAnalyzerSpec.cs
+++ b/src/Akka.Analyzers.Tests/Analyzers/AK1000/MustNotAwaitGracefulStopInsideReceiveAsyncAnalyzerSpec.cs
@@ -117,6 +117,34 @@ public class MyActor
     }
 }
 """,
+
+        // User defined `GracefulStop()` method, we're not responsible for this.
+"""
+using System;
+using Akka.Actor;
+using System.Threading.Tasks;
+
+public class MyActor: ReceiveActor
+{
+    public MyActor()
+    {
+        ReceiveAsync<string>(async str =>
+        {
+            await GracefulStop(TimeSpan.FromSeconds(3));
+        });
+
+        ReceiveAnyAsync(async _ =>
+        {
+            await GracefulStop(TimeSpan.FromSeconds(3));
+        });
+    }
+    
+    public Task GracefulStop(TimeSpan timeout)
+    {
+        return Task.CompletedTask;
+    }
+}
+""",
     };
 
     public static readonly
@@ -191,7 +219,7 @@ public sealed class MyActor : ReceiveActor
         ReceiveAnyAsync(async obj => await Context.Self.GracefulStop(TimeSpan.FromSeconds(3)));
     }
 }
-""", (9, 38, 9, 94)),            
+""", (9, 38, 9, 94)),
         };
 
     [Theory]

--- a/src/Akka.Analyzers/Utility/AkkaCoreContext.cs
+++ b/src/Akka.Analyzers/Utility/AkkaCoreContext.cs
@@ -26,6 +26,7 @@ public interface IAkkaCoreContext
     
     public INamedTypeSymbol? IndirectActorProducerType { get; }
     public INamedTypeSymbol? ReceiveActorType { get; }
+    public INamedTypeSymbol? GracefulStopSupportType { get; }
 }
 
 /// <summary>
@@ -49,6 +50,8 @@ public sealed class EmptyCoreContext : IAkkaCoreContext
     public INamedTypeSymbol? IndirectActorProducerType => null;
     
     public INamedTypeSymbol? ReceiveActorType => null;
+    
+    public INamedTypeSymbol? GracefulStopSupportType => null;
 }
 
 /// <summary>
@@ -66,6 +69,7 @@ public class AkkaCoreContext : IAkkaCoreContext
     private readonly Lazy<INamedTypeSymbol?> _lazyActorContextType;
     private readonly Lazy<INamedTypeSymbol?> _lazyIIndirectActorProducerType;
     private readonly Lazy<INamedTypeSymbol?> _lazyReceiveActorType;
+    private readonly Lazy<INamedTypeSymbol?> _lazyGracefulStopSupport;
 
     private AkkaCoreContext(Compilation compilation, Version version)
     {
@@ -76,6 +80,7 @@ public class AkkaCoreContext : IAkkaCoreContext
         _lazyActorContextType = new Lazy<INamedTypeSymbol?>(() => TypeSymbolFactory.ActorContext(compilation));
         _lazyIIndirectActorProducerType = new Lazy<INamedTypeSymbol?>(() => TypeSymbolFactory.IndirectActorProducer(compilation));
         _lazyReceiveActorType = new Lazy<INamedTypeSymbol?>(() => TypeSymbolFactory.ReceiveActor(compilation));
+        _lazyGracefulStopSupport = new Lazy<INamedTypeSymbol?>(() => TypeSymbolFactory.GracefulStopSupport(compilation));
     }
 
     /// <inheritdoc />
@@ -90,6 +95,8 @@ public class AkkaCoreContext : IAkkaCoreContext
     public INamedTypeSymbol? IndirectActorProducerType => _lazyIIndirectActorProducerType.Value;
 
     public INamedTypeSymbol? ReceiveActorType => _lazyReceiveActorType.Value;
+
+    public INamedTypeSymbol? GracefulStopSupportType => _lazyGracefulStopSupport.Value;
     
     public static AkkaCoreContext? Get(
         Compilation compilation,

--- a/src/Akka.Analyzers/Utility/RuleDescriptors.cs
+++ b/src/Akka.Analyzers/Utility/RuleDescriptors.cs
@@ -40,7 +40,7 @@ public static class RuleDescriptors
         category: AnalysisCategory.ActorDesign, 
         defaultSeverity: DiagnosticSeverity.Error,
         messageFormat: "Do not await on `Self.GracefulStop()` inside `ReceiveAsync()` because this will lead into " +
-                       "a deadlock inside the `ReceiveAsync()` and the actor will never receive the `PoisonPill` message sent by `GracefuLStop` while it's `await`-ing.");
+                       "a deadlock inside the `ReceiveAsync()` and the actor will never receive the `PoisonPill` message sent by `GracefulStop` while it's `await`-ing.");
     
     #endregion
     

--- a/src/Akka.Analyzers/Utility/TypeSymbolFactory.cs
+++ b/src/Akka.Analyzers/Utility/TypeSymbolFactory.cs
@@ -93,4 +93,8 @@ public static class TypeSymbolFactory
         return Guard.AssertIsNotNull(compilation)
             .GetTypeByMetadataName("Akka.Actor.ReceiveActor");
     }
+    
+    public static INamedTypeSymbol? GracefulStopSupport(Compilation compilation)
+        => Guard.AssertIsNotNull(compilation)
+            .GetTypeByMetadataName("Akka.Actor.GracefulStopSupport");
 }


### PR DESCRIPTION
## Changes

Make sure that the `GracefulStop()` method being invoked are defined inside `GracefulStopSupport` static class and not a custom method defined by the user.