### PR TITLE
Fix old .csproj fails to install Akka.Analyzers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # Custom
-tools/
 .nuget/
 .dotnet/
 .idea/
@@ -39,7 +38,6 @@ bld/
 
 #FAKE
 .fake
-tools/
 
 #DocFx output
 _site/

--- a/src/Akka.Analyzers.Fixes/tools/install.ps1
+++ b/src/Akka.Analyzers.Fixes/tools/install.ps1
@@ -1,0 +1,22 @@
+param($installPath, $toolsPath, $package, $project)
+
+if($project.Object.SupportsPackageDependencyResolution)
+{
+    if($project.Object.SupportsPackageDependencyResolution())
+    {
+        # Do not install analyzers via install.ps1, instead let the project system handle it.
+        return
+    }
+}
+
+$analyzersPath = Join-Path (Split-Path -Path $toolsPath -Parent) "analyzers\dotnet\roslyn3.11\cs"
+if (Test-Path $analyzersPath)
+{
+    foreach ($analyzerFilePath in Get-ChildItem -Path "$analyzersPath\*.dll" -Exclude *.resources.dll)
+    {
+        if($project.Object.AnalyzerReferences)
+        {
+            $project.Object.AnalyzerReferences.Add($analyzerFilePath.FullName)
+        }
+    }
+}

--- a/src/Akka.Analyzers.Fixes/tools/uninstall.ps1
+++ b/src/Akka.Analyzers.Fixes/tools/uninstall.ps1
@@ -1,0 +1,22 @@
+param($installPath, $toolsPath, $package, $project)
+
+if($project.Object.SupportsPackageDependencyResolution)
+{
+    if($project.Object.SupportsPackageDependencyResolution())
+    {
+        # Do not uninstall analyzers via uninstall.ps1, instead let the project system handle it.
+        return
+    }
+}
+
+$analyzersPath = Join-Path (Split-Path -Path $toolsPath -Parent) "analyzers\dotnet\roslyn3.11\cs"
+if (Test-Path $analyzersPath)
+{
+    foreach ($analyzerFilePath in Get-ChildItem -Path "$analyzersPath\*.dll" -Exclude *.resources.dll)
+    {
+        if($project.Object.AnalyzerReferences)
+        {
+            $project.Object.AnalyzerReferences.Remove($analyzerFilePath.FullName)
+        }
+    }
+}

--- a/src/Akka.Analyzers.NuGet/Akka.Analyzers.nuspec
+++ b/src/Akka.Analyzers.NuGet/Akka.Analyzers.nuspec
@@ -19,6 +19,7 @@
     <files>
         <file target="\" src="..\..\README.md" />
         <file target="\" src="..\..\logo.png" />
+        <file target="tools\" src="..\Akka.Analyzers.Fixes\tools\*.ps1" />
 
         <file target="analyzers\dotnet\roslyn4.8\cs\" src="..\Akka.Analyzers\bin\$Configuration$\netstandard2.0\Akka.Analyzers.dll" />
         <file target="analyzers\dotnet\roslyn4.8\cs\" src="..\Akka.Analyzers.Fixes\bin\$Configuration$\netstandard2.0\Akka.Analyzers.Fixes.dll" />


### PR DESCRIPTION
Fixes https://github.com/akkadotnet/akka.net/issues/7307

## Changes

Add install and uninstall script in nuspec `/tools` folder to stop IDEs from deleting Akka.Analyzers installation prematurely.

See https://github.com/akkadotnet/akka.net/issues/7307#issuecomment-2512609489 for the actual breakdown on why IDEs are failing to install Akka.Analyzers on old .NET Framework projects.

> [!WARNING]
>
> Choose between this PR or #106, do not merge both.