### PR TITLE
Add AK1008 - Should not use ActorSystem to create child actor

### DIFF
--- a/src/Akka.Analyzers.Tests/Analyzers/AK1000/ShouldNotUseSystemToCreateChildActorsAnalyzerSpecs.cs
+++ b/src/Akka.Analyzers.Tests/Analyzers/AK1000/ShouldNotUseSystemToCreateChildActorsAnalyzerSpecs.cs
@@ -1,0 +1,250 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="ShouldNotUseSystemToCreateChildActorsAnalyzerSpecs.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Microsoft.CodeAnalysis;
+using Verify = Akka.Analyzers.Tests.Utility.AkkaVerifier<Akka.Analyzers.ShouldNotUseSystemToCreateChildActorsAnalyzer>;
+
+namespace Akka.Analyzers.Tests.Analyzers.AK1000;
+
+public class ShouldNotUseSystemToCreateChildActorsAnalyzerSpecs
+{
+        public static readonly TheoryData<string> SuccessCases = new()
+    {
+        // Non-actor class uses ActorSystem to create an actor
+"""
+using Akka.Actor;
+
+public class SaveClass
+{
+    public SaveClass(ActorSystem system)
+    {
+        system.ActorOf(Props.Create(() => new ChildActor())); // Shouldn't flag this
+        system.ActorOf<ChildActor>(); // Shouldn't flag this
+    }
+}
+
+public class ChildActor : ReceiveActor
+{
+}
+""",
+
+        // Actors using Context to create child actors
+"""
+using Akka.Actor;
+
+public class MyActor : ReceiveActor
+{
+    public MyActor()
+    {
+        Context.ActorOf(Props.Create(() => new ChildActor())); // Shouldn't flag this
+        Context.ActorOf<ChildActor>(); // Shouldn't flag this
+    }
+}
+
+public class ChildActor : ReceiveActor
+{
+}
+""",
+    };
+
+    public static readonly
+        TheoryData<(string testData, (int startLine, int startColumn, int endLine, int endColumn) spanData)>
+        FailureCases = new()
+        {
+            // ReceiveActor invoking ActorSystem.ActorOf() directly
+            (
+"""
+// 01
+using Akka.Actor;
+
+public class MyActor : ReceiveActor
+{
+    public MyActor(ActorSystem system)
+    {
+        system.ActorOf(Props.Create(() => new ChildActor()));
+    }
+}
+
+public class ChildActor : ReceiveActor
+{
+}
+""", (8, 9, 8, 61)),
+            
+            // ReceiveActor invoking Context.System.ActorOf()
+            (
+"""
+// 02
+using Akka.Actor;
+
+public class MyActor : ReceiveActor
+{
+    public MyActor()
+    {
+        Context.System.ActorOf(Props.Create(() => new ChildActor()));
+    }
+}
+
+public class ChildActor : ReceiveActor
+{
+}
+""", (8, 9, 8, 69)),
+            
+            // ReceiveActor invoking ActorOf<T>() extension on ActorSystem directly
+            (
+"""
+// 03
+using Akka.Actor;
+
+public class MyActor : ReceiveActor
+{
+    public MyActor(ActorSystem system)
+    {
+        system.ActorOf<ChildActor>();
+    }
+}
+
+public class ChildActor : ReceiveActor
+{
+}
+""", (8, 9, 8, 37)),
+            
+            // ReceiveActor invoking ActorOf<T>() extension on Context.System
+            (
+"""
+// 04
+using Akka.Actor;
+
+public class MyActor : ReceiveActor
+{
+    public MyActor()
+    {
+        Context.System.ActorOf<ChildActor>();
+    }
+}
+
+public class ChildActor : ReceiveActor
+{
+}
+""", (8, 9, 8, 45)),
+            
+            
+            // UntypedActor invoking ActorSystem.ActorOf() directly
+            (
+"""
+// 05
+using Akka.Actor;
+
+public class MyActor : UntypedActor
+{
+    public MyActor(ActorSystem system)
+    {
+        system.ActorOf(Props.Create(() => new ChildActor()));
+    }
+
+    protected override void OnReceive(object message)
+    {
+        throw new System.NotImplementedException();
+    }
+}
+
+public class ChildActor : ReceiveActor
+{
+}
+""", (8, 9, 8, 61)),
+            
+            // UntypedActor invoking Context.System.ActorOf()
+            (
+"""
+// 06
+using Akka.Actor;
+
+public class MyActor : UntypedActor
+{
+    public MyActor()
+    {
+        Context.System.ActorOf(Props.Create(() => new ChildActor()));
+    }
+
+    protected override void OnReceive(object message)
+    {
+        throw new System.NotImplementedException();
+    }
+}
+
+public class ChildActor : ReceiveActor
+{
+}
+""", (8, 9, 8, 69)),
+            
+            // UntypedActor invoking ActorOf<T>() extension on ActorSystem directly
+            (
+"""
+// 07
+using Akka.Actor;
+
+public class MyActor : UntypedActor
+{
+    public MyActor(ActorSystem system)
+    {
+        system.ActorOf<ChildActor>();
+    }
+
+    protected override void OnReceive(object message)
+    {
+        throw new System.NotImplementedException();
+    }
+}
+
+public class ChildActor : ReceiveActor
+{
+}
+""", (8, 9, 8, 37)),
+            
+            // UntypedActor invoking ActorOf<T>() extension on Context.System
+            (
+"""
+// 08
+using Akka.Actor;
+
+public class MyActor : UntypedActor
+{
+    public MyActor()
+    {
+        Context.System.ActorOf<ChildActor>();
+    }
+
+    protected override void OnReceive(object message)
+    {
+        throw new System.NotImplementedException();
+    }
+}
+
+public class ChildActor : ReceiveActor
+{
+}
+""", (8, 9, 8, 45)),
+        };
+
+    [Theory]
+    [MemberData(nameof(SuccessCases))]
+    public async Task SuccessCase(string testCode)
+    {
+        await Verify.VerifyAnalyzer(testCode).ConfigureAwait(true);
+    }
+
+    [Theory]
+    [MemberData(nameof(FailureCases))]
+    public Task FailureCase(
+        (string testCode, (int startLine, int startColumn, int endLine, int endColumn) spanData) d)
+    {
+        var expected = Verify.Diagnostic()
+            .WithSpan(d.spanData.startLine, d.spanData.startColumn, d.spanData.endLine, d.spanData.endColumn)
+            .WithSeverity(DiagnosticSeverity.Warning);
+
+        return Verify.VerifyAnalyzer(d.testCode, expected);
+    }
+
+}

--- a/src/Akka.Analyzers/AK1000/ShouldNotUseSystemToCreateChildActorsAnalyzer.cs
+++ b/src/Akka.Analyzers/AK1000/ShouldNotUseSystemToCreateChildActorsAnalyzer.cs
@@ -1,0 +1,104 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="MustCloseOverSenderWhenUsingReceiveAsyncAnalyzer.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2024 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System.Collections.Immutable;
+using Akka.Analyzers.Context;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Akka.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class ShouldNotUseSystemToCreateChildActorsAnalyzer()
+    : AkkaDiagnosticAnalyzer(RuleDescriptors.Ak1008ShouldNotUseSystemToCreateChildActor)
+{
+    public override void AnalyzeCompilation(CompilationStartAnalysisContext context, AkkaContext akkaContext)
+    {
+        Guard.AssertIsNotNull(context);
+        Guard.AssertIsNotNull(akkaContext);
+
+        context.RegisterSyntaxNodeAction(ctx =>
+        {
+            var invocationExpression = (InvocationExpressionSyntax)ctx.Node;
+            var semanticModel = ctx.SemanticModel;
+            
+            // Get the member symbol from the invocation expression
+            if(semanticModel.GetSymbolInfo(invocationExpression.Expression).Symbol is not IMethodSymbol methodInvocationSymbol)
+                return;
+            
+            // Make sure we get the actual method if it's an extension method
+            if (methodInvocationSymbol.IsExtensionMethod)
+            {
+                // Method must be accessing a member of an instance
+                if(invocationExpression.Expression is not MemberAccessExpressionSyntax memberAccess)
+                    return;
+                
+                // Accessed member must be of type `ActorSystem`
+                var receiverType = semanticModel.GetTypeInfo(memberAccess.Expression).Type;
+                if (receiverType is null)
+                    return;
+
+                if (!receiverType.IsDerivedOrImplements(akkaContext.AkkaCore.Actor.ActorSystemType!))
+                    return;
+                
+                // Make sure that we're accessing the actual method
+                while (methodInvocationSymbol.ReducedFrom is not null)
+                {
+                    methodInvocationSymbol = methodInvocationSymbol.ReducedFrom;
+                }
+
+                // Method must be the `ActorOf<T>()` extension method
+                if (!ReferenceEquals(methodInvocationSymbol, akkaContext.AkkaCore.Actor.ActorRefFactoryExtensions.ActorOf))
+                    return;
+            }
+            else
+            {
+                // Check if the method matches any `ActorOf` methods
+                if (!ReferenceEquals(methodInvocationSymbol, akkaContext.AkkaCore.Actor.ActorSystem.ActorOf))
+                    return;
+            }
+            
+            // Traverse up the parent nodes to see if any of them are ActorBase classes
+            AssertInvocationIsInClassType(invocationExpression, semanticModel, akkaContext.AkkaCore.Actor.ActorBaseType, ctx);
+            
+        }, SyntaxKind.InvocationExpression);
+    }
+
+    /// <summary>
+    /// Traverse up the parent nodes to see if any of them derived from a certain class
+    /// </summary>
+    private static void AssertInvocationIsInClassType(
+        InvocationExpressionSyntax invocationExpression, 
+        SemanticModel semanticModel,
+        INamedTypeSymbol? classType,
+        SyntaxNodeAnalysisContext context)
+    {
+        if(classType is null)
+            return;
+        
+        var parent = invocationExpression.Parent;
+        while (parent != null)
+        {
+            if (parent is ClassDeclarationSyntax classDeclaration)
+            {
+                var isActorType = classDeclaration.IsDerivedOrImplements(semanticModel, classType);
+                if (isActorType)
+                {
+                    // If found, report a diagnostic
+                    var diagnostic = Diagnostic.Create(
+                        descriptor: RuleDescriptors.Ak1008ShouldNotUseSystemToCreateChildActor, 
+                        location: invocationExpression.GetLocation());
+                    context.ReportDiagnostic(diagnostic);
+                    return;
+                }
+            }
+                
+            parent = parent.Parent;
+        }
+    }
+}

--- a/src/Akka.Analyzers/Context/Core/Actor/ActorRefFactoryExtensionsContext.cs
+++ b/src/Akka.Analyzers/Context/Core/Actor/ActorRefFactoryExtensionsContext.cs
@@ -1,0 +1,45 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="ActorRefFactoryExtensionsContext.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Microsoft.CodeAnalysis;
+
+namespace Akka.Analyzers.Context.Core.Actor;
+
+public interface IActorRefFactoryExtensionsContext
+{
+    public IMethodSymbol? ActorOf { get; }
+    public IMethodSymbol? ActorSelection { get; }
+}
+
+public sealed class EmptyActorRefFactoryExtensionsContext : IActorRefFactoryExtensionsContext
+{
+    public static EmptyActorRefFactoryExtensionsContext Instance { get; } = new ();
+    
+    private EmptyActorRefFactoryExtensionsContext() { }
+
+    public IMethodSymbol? ActorOf => null;
+    public IMethodSymbol? ActorSelection => null;
+}
+
+public sealed class ActorRefFactoryExtensionsContext : IActorRefFactoryExtensionsContext
+{
+    private readonly Lazy<IMethodSymbol> _lazyActorOf;
+    private readonly Lazy<IMethodSymbol> _lazyActorSelection;
+
+    private ActorRefFactoryExtensionsContext(IAkkaCoreActorContext context)
+    {
+        _lazyActorOf = new Lazy<IMethodSymbol>(() => (IMethodSymbol) context.ActorRefFactoryExtensionsType!
+            .GetMembers(nameof(ActorOf)).First());
+        _lazyActorSelection = new Lazy<IMethodSymbol>(() => (IMethodSymbol) context.ActorRefFactoryExtensionsType!
+            .GetMembers(nameof(ActorSelection)).First());
+    }
+    
+    public IMethodSymbol? ActorOf => _lazyActorOf.Value;
+    public IMethodSymbol? ActorSelection => _lazyActorSelection.Value;
+    
+    public static ActorRefFactoryExtensionsContext Get(IAkkaCoreActorContext context)
+        => new(context);
+}

--- a/src/Akka.Analyzers/Context/Core/Actor/ActorSymbolFactory.cs
+++ b/src/Akka.Analyzers/Context/Core/Actor/ActorSymbolFactory.cs
@@ -16,6 +16,14 @@ public static class ActorSymbolFactory
         => Guard.AssertIsNotNull(compilation)
             .GetTypeByMetadataName($"{AkkaActorNamespace}.ActorBase");
 
+    public static INamedTypeSymbol? ActorSystem(Compilation compilation)
+        => Guard.AssertIsNotNull(compilation)
+            .GetTypeByMetadataName($"{AkkaActorNamespace}.ActorSystem");
+
+    public static INamedTypeSymbol? ActorRefFactoryExtensions(Compilation compilation)
+        => Guard.AssertIsNotNull(compilation)
+            .GetTypeByMetadataName($"{AkkaActorNamespace}.ActorRefFactoryExtensions");
+
     public static INamedTypeSymbol? ActorReference(Compilation compilation)
         => Guard.AssertIsNotNull(compilation)
             .GetTypeByMetadataName($"{AkkaActorNamespace}.IActorRef");

--- a/src/Akka.Analyzers/Context/Core/Actor/ActorSystemContext.cs
+++ b/src/Akka.Analyzers/Context/Core/Actor/ActorSystemContext.cs
@@ -1,0 +1,186 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="ActorSystemContext.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+
+namespace Akka.Analyzers.Context.Core.Actor;
+
+public interface IActorSystemContext
+{
+    public IPropertySymbol? Settings { get; }
+    public IPropertySymbol? Name { get; }
+    public IPropertySymbol? Serialization { get; }
+    public IPropertySymbol? EventStream { get; }
+    public IPropertySymbol? DeadLetters { get; }
+    public IPropertySymbol? IgnoreRef { get; }
+    public IPropertySymbol? Dispatchers { get; }
+    public IPropertySymbol? Mailboxes { get; }
+    public IPropertySymbol? Scheduler { get; }
+    public IPropertySymbol? Log { get; }
+    public IPropertySymbol? StartTime { get; }
+    public IPropertySymbol? Uptime { get; }
+    public IPropertySymbol? WhenTerminated { get; }
+    
+    public ImmutableArray<IMethodSymbol> GetExtension { get; }
+    public ImmutableArray<IMethodSymbol> HasExtension { get; }
+    public ImmutableArray<IMethodSymbol> TryGetExtension { get; }
+    public IMethodSymbol? RegisterOnTermination { get; }
+    public IMethodSymbol? Terminate { get; }
+    public IMethodSymbol? FinalTerminate { get; }
+#pragma warning disable CA1716
+    public IMethodSymbol? Stop { get; }
+#pragma warning restore CA1716
+    public ImmutableArray<IMethodSymbol> Dispose { get; }
+    public IMethodSymbol? RegisterExtension { get; }
+    public IMethodSymbol? ActorOf { get; }
+    public ImmutableArray<IMethodSymbol> ActorSelection { get; }
+}
+
+public sealed class EmptyActorSystemContext : IActorSystemContext
+{
+    public static readonly IActorSystemContext Instance = new EmptyActorSystemContext();
+    private EmptyActorSystemContext() { }
+    
+    public IPropertySymbol? Settings => null;
+    public IPropertySymbol? Name => null;
+    public IPropertySymbol? Serialization => null;
+    public IPropertySymbol? EventStream => null;
+    public IPropertySymbol? DeadLetters => null;
+    public IPropertySymbol? IgnoreRef => null;
+    public IPropertySymbol? Dispatchers => null;
+    public IPropertySymbol? Mailboxes => null;
+    public IPropertySymbol? Scheduler => null;
+    public IPropertySymbol? Log => null;
+    public IPropertySymbol? StartTime => null;
+    public IPropertySymbol? Uptime => null;
+    public IPropertySymbol? WhenTerminated => null;
+    
+    public ImmutableArray<IMethodSymbol> GetExtension => ImmutableArray<IMethodSymbol>.Empty;
+    public ImmutableArray<IMethodSymbol> HasExtension => ImmutableArray<IMethodSymbol>.Empty;
+    public ImmutableArray<IMethodSymbol> TryGetExtension => ImmutableArray<IMethodSymbol>.Empty;
+    public IMethodSymbol? RegisterOnTermination => null;
+    public IMethodSymbol? Terminate => null;
+    public IMethodSymbol? FinalTerminate => null;
+    public IMethodSymbol? Stop => null;
+    public ImmutableArray<IMethodSymbol> Dispose => ImmutableArray<IMethodSymbol>.Empty;
+    public IMethodSymbol? RegisterExtension => null;
+    public IMethodSymbol? ActorOf => null;
+    public ImmutableArray<IMethodSymbol> ActorSelection => ImmutableArray<IMethodSymbol>.Empty;
+}
+
+public sealed class ActorSystemContext : IActorSystemContext
+{
+    private readonly Lazy<IPropertySymbol> _lazySettings;
+    private readonly Lazy<IPropertySymbol> _lazyName;
+    private readonly Lazy<IPropertySymbol> _lazySerialization;
+    private readonly Lazy<IPropertySymbol> _lazyEventStream;
+    private readonly Lazy<IPropertySymbol> _lazyDeadLetters;
+    private readonly Lazy<IPropertySymbol> _lazyIgnoreRef;
+    private readonly Lazy<IPropertySymbol> _lazyDispatchers;
+    private readonly Lazy<IPropertySymbol> _lazyMailboxes;
+    private readonly Lazy<IPropertySymbol> _lazyScheduler;
+    private readonly Lazy<IPropertySymbol> _lazyLog;
+    private readonly Lazy<IPropertySymbol> _lazyStartTime;
+    private readonly Lazy<IPropertySymbol> _lazyUptime;
+    private readonly Lazy<IPropertySymbol> _lazyWhenTerminated;
+    
+    private readonly Lazy<ImmutableArray<IMethodSymbol>> _lazyGetExtension;
+    private readonly Lazy<ImmutableArray<IMethodSymbol>> _lazyHasExtension;
+    private readonly Lazy<ImmutableArray<IMethodSymbol>> _lazyTryGetExtension;
+    private readonly Lazy<IMethodSymbol> _lazyRegisterOnTermination;
+    private readonly Lazy<IMethodSymbol> _lazyTerminate;
+    private readonly Lazy<IMethodSymbol> _lazyFinalTerminate;
+    private readonly Lazy<IMethodSymbol> _lazyStop;
+    private readonly Lazy<ImmutableArray<IMethodSymbol>> _lazyDispose;
+    private readonly Lazy<IMethodSymbol> _lazyRegisterExtension;
+    private readonly Lazy<IMethodSymbol> _lazyActorOf;
+    private readonly Lazy<ImmutableArray<IMethodSymbol>> _lazyActorSelection;
+    
+    private ActorSystemContext(IAkkaCoreActorContext context)
+    {
+        _lazySettings = new Lazy<IPropertySymbol>(() => (IPropertySymbol) context.ActorSystemType!
+            .GetMembers(nameof(Settings)).First());
+        _lazyName = new Lazy<IPropertySymbol>(() => (IPropertySymbol) context.ActorSystemType!
+            .GetMembers(nameof(Name)).First());
+        _lazySerialization = new Lazy<IPropertySymbol>(() => (IPropertySymbol) context.ActorSystemType!
+            .GetMembers(nameof(Serialization)).First());
+        _lazyEventStream = new Lazy<IPropertySymbol>(() => (IPropertySymbol) context.ActorSystemType!
+            .GetMembers(nameof(EventStream)).First());
+        _lazyDeadLetters = new Lazy<IPropertySymbol>(() => (IPropertySymbol) context.ActorSystemType!
+            .GetMembers(nameof(DeadLetters)).First());
+        _lazyIgnoreRef = new Lazy<IPropertySymbol>(() => (IPropertySymbol) context.ActorSystemType!
+            .GetMembers(nameof(IgnoreRef)).First());
+        _lazyDispatchers = new Lazy<IPropertySymbol>(() => (IPropertySymbol) context.ActorSystemType!
+            .GetMembers(nameof(Dispatchers)).First());
+        _lazyMailboxes = new Lazy<IPropertySymbol>(() => (IPropertySymbol) context.ActorSystemType!
+            .GetMembers(nameof(Mailboxes)).First());
+        _lazyScheduler = new Lazy<IPropertySymbol>(() => (IPropertySymbol) context.ActorSystemType!
+            .GetMembers(nameof(Scheduler)).First());
+        _lazyLog = new Lazy<IPropertySymbol>(() => (IPropertySymbol) context.ActorSystemType!
+            .GetMembers(nameof(Log)).First());
+        _lazyStartTime = new Lazy<IPropertySymbol>(() => (IPropertySymbol) context.ActorSystemType!
+            .GetMembers(nameof(StartTime)).First());
+        _lazyUptime = new Lazy<IPropertySymbol>(() => (IPropertySymbol) context.ActorSystemType!
+            .GetMembers(nameof(Uptime)).First());
+        _lazyWhenTerminated = new Lazy<IPropertySymbol>(() => (IPropertySymbol) context.ActorSystemType!
+            .GetMembers(nameof(WhenTerminated)).First());
+        
+        _lazyGetExtension = new Lazy<ImmutableArray<IMethodSymbol>>(() => context.ActorSystemType!
+            .GetMembers(nameof(GetExtension)).Select(m => (IMethodSymbol)m).ToImmutableArray());
+        _lazyHasExtension = new Lazy<ImmutableArray<IMethodSymbol>>(() => context.ActorSystemType!
+            .GetMembers(nameof(HasExtension)).Select(m => (IMethodSymbol)m).ToImmutableArray());
+        _lazyTryGetExtension = new Lazy<ImmutableArray<IMethodSymbol>>(() => context.ActorSystemType!
+            .GetMembers(nameof(TryGetExtension)).Select(m => (IMethodSymbol)m).ToImmutableArray());
+        
+        _lazyRegisterOnTermination = new Lazy<IMethodSymbol>(() => (IMethodSymbol) context.ActorSystemType!
+            .GetMembers(nameof(RegisterOnTermination)).First());
+        _lazyTerminate = new Lazy<IMethodSymbol>(() => (IMethodSymbol) context.ActorSystemType!
+            .GetMembers(nameof(Terminate)).First());
+        _lazyFinalTerminate = new Lazy<IMethodSymbol>(() => (IMethodSymbol) context.ActorSystemType!
+            .GetMembers(nameof(FinalTerminate)).First());
+        _lazyStop = new Lazy<IMethodSymbol>(() => (IMethodSymbol) context.ActorSystemType!
+            .GetMembers(nameof(Stop)).First());
+        
+        _lazyDispose = new Lazy<ImmutableArray<IMethodSymbol>>(() => context.ActorSystemType!
+            .GetMembers(nameof(Dispose)).Select(m => (IMethodSymbol)m).ToImmutableArray());
+        _lazyRegisterExtension = new Lazy<IMethodSymbol>(() => (IMethodSymbol) context.ActorSystemType!
+            .GetMembers(nameof(RegisterExtension)).First());
+        _lazyActorOf = new Lazy<IMethodSymbol>(() => (IMethodSymbol) context.ActorSystemType!
+            .GetMembers(nameof(ActorOf)).First());
+        _lazyActorSelection = new Lazy<ImmutableArray<IMethodSymbol>>(() => context.ActorSystemType!
+            .GetMembers(nameof(ActorSelection)).Select(m => (IMethodSymbol)m).ToImmutableArray());
+    }
+    
+    public IPropertySymbol? Settings => _lazySettings.Value;
+    public IPropertySymbol? Name => _lazyName.Value;
+    public IPropertySymbol? Serialization => _lazySerialization.Value;
+    public IPropertySymbol? EventStream => _lazyEventStream.Value;
+    public IPropertySymbol? DeadLetters => _lazyDeadLetters.Value;
+    public IPropertySymbol? IgnoreRef => _lazyIgnoreRef.Value;
+    public IPropertySymbol? Dispatchers => _lazyDispatchers.Value;
+    public IPropertySymbol? Mailboxes => _lazyMailboxes.Value;
+    public IPropertySymbol? Scheduler => _lazyScheduler.Value;
+    public IPropertySymbol? Log => _lazyLog.Value;
+    public IPropertySymbol? StartTime => _lazyStartTime.Value;
+    public IPropertySymbol? Uptime => _lazyUptime.Value;
+    public IPropertySymbol? WhenTerminated => _lazyWhenTerminated.Value;
+    
+    public ImmutableArray<IMethodSymbol> GetExtension => _lazyGetExtension.Value;
+    public ImmutableArray<IMethodSymbol> HasExtension => _lazyHasExtension.Value;
+    public ImmutableArray<IMethodSymbol> TryGetExtension => _lazyTryGetExtension.Value;
+    public IMethodSymbol? RegisterOnTermination => _lazyRegisterOnTermination.Value;
+    public IMethodSymbol? Terminate => _lazyTerminate.Value;
+    public IMethodSymbol? FinalTerminate => _lazyFinalTerminate.Value;
+    public IMethodSymbol? Stop => _lazyStop.Value;
+    public ImmutableArray<IMethodSymbol> Dispose => _lazyDispose.Value;
+    public IMethodSymbol? RegisterExtension => _lazyRegisterExtension.Value;
+    public IMethodSymbol? ActorOf => _lazyActorOf.Value;
+    public ImmutableArray<IMethodSymbol> ActorSelection => _lazyActorSelection.Value;
+    
+    public static ActorSystemContext Get(IAkkaCoreActorContext context)
+        => new(context);
+}

--- a/src/Akka.Analyzers/Context/Core/Actor/AkkaCoreActorContext.cs
+++ b/src/Akka.Analyzers/Context/Core/Actor/AkkaCoreActorContext.cs
@@ -14,6 +14,8 @@ public sealed class EmptyAkkaCoreActorContext : IAkkaCoreActorContext
     private EmptyAkkaCoreActorContext() { }
     public static EmptyAkkaCoreActorContext Instance { get; } = new();
     public INamedTypeSymbol? ActorBaseType => null;
+    public INamedTypeSymbol? ActorSystemType => null;
+    public INamedTypeSymbol? ActorRefFactoryExtensionsType => null;
     public INamedTypeSymbol? IActorRefType => null;
     public INamedTypeSymbol? PropsType => null;
     public INamedTypeSymbol? IActorContextType => null;
@@ -24,7 +26,9 @@ public sealed class EmptyAkkaCoreActorContext : IAkkaCoreActorContext
     public INamedTypeSymbol? ActorRefsType => null;
     public INamedTypeSymbol? ITimerSchedulerType => null;
 
+    public IActorSystemContext ActorSystem => EmptyActorSystemContext.Instance;
     public IGracefulStopSupportContext GracefulStopSupportSupport => EmptyGracefulStopSupportContext.Instance;
+    public IActorRefFactoryExtensionsContext ActorRefFactoryExtensions => EmptyActorRefFactoryExtensionsContext.Instance;
     public IIndirectActorProducerContext IIndirectActorProducer => EmptyIndirectActorProducerContext.Instance;
     public IReceiveActorContext ReceiveActor => EmptyReceiveActorContext.Instance;
     public IActorBaseContext ActorBase => EmptyActorBaseContext.Instance;
@@ -38,6 +42,8 @@ public sealed class EmptyAkkaCoreActorContext : IAkkaCoreActorContext
 public sealed class AkkaCoreActorContext : IAkkaCoreActorContext
 {
     private readonly Lazy<INamedTypeSymbol?> _lazyActorBaseType;
+    private readonly Lazy<INamedTypeSymbol?> _lazyActorSystemType;
+    private readonly Lazy<INamedTypeSymbol?> _lazyActorRefFactoryExtensionsType;
     private readonly Lazy<INamedTypeSymbol?> _lazyActorRefType;
     private readonly Lazy<INamedTypeSymbol?> _lazyPropsType;
     private readonly Lazy<INamedTypeSymbol?> _lazyActorContextType;
@@ -48,6 +54,8 @@ public sealed class AkkaCoreActorContext : IAkkaCoreActorContext
     private readonly Lazy<INamedTypeSymbol?> _lazyActorRefsType;
     private readonly Lazy<INamedTypeSymbol?> _lazyITimerSchedulerType;
     
+    private readonly Lazy<IActorSystemContext> _lazyActorSystem;
+    private readonly Lazy<IActorRefFactoryExtensionsContext> _lazyActorRefFactoryExtensions;
     private readonly Lazy<IGracefulStopSupportContext> _lazyGracefulStopSupport;
     private readonly Lazy<IIndirectActorProducerContext> _lazyIIndirectActorProducer;
     private readonly Lazy<IReceiveActorContext> _lazyReceiveActor;
@@ -58,6 +66,8 @@ public sealed class AkkaCoreActorContext : IAkkaCoreActorContext
     private AkkaCoreActorContext(Compilation compilation)
     {
         _lazyActorBaseType = new Lazy<INamedTypeSymbol?>(() => ActorSymbolFactory.ActorBase(compilation));
+        _lazyActorSystemType = new Lazy<INamedTypeSymbol?>(() => ActorSymbolFactory.ActorSystem(compilation));
+        _lazyActorRefFactoryExtensionsType = new Lazy<INamedTypeSymbol?>(() => ActorSymbolFactory.ActorRefFactoryExtensions(compilation));
         _lazyActorRefType = new Lazy<INamedTypeSymbol?>(() => ActorSymbolFactory.ActorReference(compilation));
         _lazyPropsType = new Lazy<INamedTypeSymbol?>(() => ActorSymbolFactory.Props(compilation));
         _lazyActorContextType = new Lazy<INamedTypeSymbol?>(() => ActorSymbolFactory.ActorContext(compilation));
@@ -67,7 +77,9 @@ public sealed class AkkaCoreActorContext : IAkkaCoreActorContext
         _lazyTellSchedulerInterface = new Lazy<INamedTypeSymbol?>(() => ActorSymbolFactory.TellSchedulerInterface(compilation));
         _lazyActorRefsType = new Lazy<INamedTypeSymbol?>(() => ActorSymbolFactory.ActorRefs(compilation));
         _lazyITimerSchedulerType = new Lazy<INamedTypeSymbol?>(() => ActorSymbolFactory.TimerSchedulerInterface(compilation));
-        
+
+        _lazyActorSystem = new Lazy<IActorSystemContext>(() => ActorSystemContext.Get(this));
+        _lazyActorRefFactoryExtensions = new Lazy<IActorRefFactoryExtensionsContext>(() => ActorRefFactoryExtensionsContext.Get(this));
         _lazyGracefulStopSupport = new Lazy<IGracefulStopSupportContext>(() => GracefulStopSupportContext.Get(this));
         _lazyIIndirectActorProducer = new Lazy<IIndirectActorProducerContext>(() => IndirectActorProducerContext.Get(this));
         _lazyReceiveActor = new Lazy<IReceiveActorContext>(() => ReceiveActorContext.Get(this));
@@ -80,6 +92,8 @@ public sealed class AkkaCoreActorContext : IAkkaCoreActorContext
     }
 
     public INamedTypeSymbol? ActorBaseType => _lazyActorBaseType.Value;
+    public INamedTypeSymbol? ActorSystemType => _lazyActorSystemType.Value;
+    public INamedTypeSymbol? ActorRefFactoryExtensionsType => _lazyActorRefFactoryExtensionsType.Value;
     public INamedTypeSymbol? IActorRefType => _lazyActorRefType.Value;
     public INamedTypeSymbol? PropsType => _lazyPropsType.Value;
     public INamedTypeSymbol? IActorContextType => _lazyActorContextType.Value;
@@ -90,7 +104,9 @@ public sealed class AkkaCoreActorContext : IAkkaCoreActorContext
     public INamedTypeSymbol? GracefulStopSupportType => _lazyGracefulStopSupportType.Value;
     public INamedTypeSymbol? ITimerSchedulerType => _lazyITimerSchedulerType.Value;
     
+    public IActorSystemContext ActorSystem => _lazyActorSystem.Value;
     public IGracefulStopSupportContext GracefulStopSupportSupport => _lazyGracefulStopSupport.Value;
+    public IActorRefFactoryExtensionsContext ActorRefFactoryExtensions => _lazyActorRefFactoryExtensions.Value;
     public IIndirectActorProducerContext IIndirectActorProducer => _lazyIIndirectActorProducer.Value;
     public IReceiveActorContext ReceiveActor => _lazyReceiveActor.Value;
     public IActorBaseContext ActorBase => _lazyActorBase.Value;

--- a/src/Akka.Analyzers/Context/Core/Actor/IAkkaCoreActorContext.cs
+++ b/src/Akka.Analyzers/Context/Core/Actor/IAkkaCoreActorContext.cs
@@ -13,6 +13,8 @@ namespace Akka.Analyzers.Context.Core.Actor;
 public interface IAkkaCoreActorContext
 {
     public INamedTypeSymbol? ActorBaseType { get; }
+    public INamedTypeSymbol? ActorSystemType { get; }
+    public INamedTypeSymbol? ActorRefFactoryExtensionsType { get; }
     public INamedTypeSymbol? IActorRefType { get; }
     public INamedTypeSymbol? PropsType { get; }
     public INamedTypeSymbol? IActorContextType { get; }
@@ -23,7 +25,9 @@ public interface IAkkaCoreActorContext
     public INamedTypeSymbol? ActorRefsType { get; }
     public INamedTypeSymbol? ITimerSchedulerType { get; } 
     
+    public IActorSystemContext ActorSystem { get; }
     public IGracefulStopSupportContext GracefulStopSupportSupport { get; }
+    public IActorRefFactoryExtensionsContext ActorRefFactoryExtensions { get; }
     public IIndirectActorProducerContext IIndirectActorProducer { get; }
     public IReceiveActorContext ReceiveActor { get; }
     public IActorBaseContext ActorBase { get; }

--- a/src/Akka.Analyzers/Utility/RuleDescriptors.cs
+++ b/src/Akka.Analyzers/Utility/RuleDescriptors.cs
@@ -87,6 +87,15 @@ public static class RuleDescriptors
         defaultSeverity: DiagnosticSeverity.Error,
         messageFormat: "Creating timer registration using `{0}()` in `{1}()` will not be honored because they will be " +
                        "cleared immediately. Move timer creation to `PostRestart()` instead.");
+    
+    public static DiagnosticDescriptor Ak1008ShouldNotUseSystemToCreateChildActor { get; } = Rule(
+        id: "AK1008",
+        title: "Creating actors using `ActorSystem.ActorOf()` inside an actor.", 
+        category: AnalysisCategory.ActorDesign, 
+        defaultSeverity: DiagnosticSeverity.Warning,
+        messageFormat: "Creating actors using `ActorSystem.ActorOf` inside an actor is discouraged because the " +
+                       "resulting actor would not be the child of this actor but the system itself. Please use " +
+                       "`ActorContext.ActorOf` if your intention is to create a child actor of this actor.");
     #endregion
     
     #region AK2000 Rules


### PR DESCRIPTION
Fixes #

Add AK1008, issue a warning if users tried to use `Context.System.ActorOf()`, `Context.System.ActorOf<T>()`, `ActorSystem.ActorOf()` and `ActorSystem.ActorOf<T>()` inside a class that derive from `ActorBase`

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
