### PR TITLE
AK2001 - Add `as` cast expression detection

### DIFF
--- a/src/Akka.Analyzers.Tests/Analyzers/AK2000/MustNotHandleAutomaticallyHandledMessagesInMessageExtractorAnalyzerSpecs.cs
+++ b/src/Akka.Analyzers.Tests/Analyzers/AK2000/MustNotHandleAutomaticallyHandledMessagesInMessageExtractorAnalyzerSpecs.cs
@@ -333,7 +333,47 @@ public class MsgExtractorCreator{
 """, new[]
 {
     (10, 26, 10, 48)
-})
+}),
+        
+                    (
+        // Simple message extractor edge case - using expression body instead of block
+"""
+// 01
+using Akka.Cluster.Sharding;
+public sealed class ShardMessageExtractor : HashCodeMessageExtractor
+{
+    /// <summary>
+    /// We only ever run with a maximum of two nodes, so ~10 shards per node
+    /// </summary>
+    public ShardMessageExtractor(int shardCount = 20) : base(shardCount)
+    {
+    }
+
+    public override string EntityId(object message)
+        => (message as ShardingEnvelope)?.EntityId ?? null;
+}
+""", new[]{(13, 13, 13, 40)}),
+
+                    (
+        // Simple message extractor edge case - using `as`
+"""
+// 02
+using Akka.Cluster.Sharding;
+public sealed class ShardMessageExtractor : HashCodeMessageExtractor
+{
+    /// <summary>
+    /// We only ever run with a maximum of two nodes, so ~10 shards per node
+    /// </summary>
+    public ShardMessageExtractor(int shardCount = 20) : base(shardCount)
+    {
+    }
+
+    public override string EntityId(object message)
+    {
+        return (message as ShardingEnvelope)?.EntityId ?? null;
+    }
+}
+""", new[]{(14, 17, 14, 44)}),
         };
     
     [Theory]

--- a/src/Akka.Analyzers/AK2000/MustNotUseAutomaticallyHandledMessagesInsideMessageExtractorAnalyzer.cs
+++ b/src/Akka.Analyzers/AK2000/MustNotUseAutomaticallyHandledMessagesInsideMessageExtractorAnalyzer.cs
@@ -159,6 +159,24 @@ public class MustNotUseAutomaticallyHandledMessagesInsideMessageExtractorAnalyze
 
                 break;
             }
+            
+            case BinaryExpressionSyntax binaryExpressionSyntax when binaryExpressionSyntax.IsKind(SyntaxKind.AsExpression) && binaryExpressionSyntax.Right is TypeSyntax typeSyntax:
+                var typeSymbol = semanticModel.GetTypeInfo(typeSyntax).Type;
+                if (forbiddenTypes.Any(t => SymbolEqualityComparer.Default.Equals(t, typeSymbol)))
+                {
+                    var location = binaryExpressionSyntax.GetLocation();
+
+                    // duplicate
+                    if (reportedLocations.Contains(location))
+                        break;
+                    var diagnostic = Diagnostic.Create(
+                        RuleDescriptors
+                            .Ak2001DoNotUseAutomaticallyHandledMessagesInShardMessageExtractor,
+                        location);
+                    ctx.ReportDiagnostic(diagnostic);
+                    reportedLocations.Add(location);
+                }
+                break;
         }
     }
 }


### PR DESCRIPTION
## Changes

The present rule does not detect if the forbidden types were cast using the `as` expression

