### PR TITLE
AK2002 - Add multi `Context.Materializer()` invocation detection

### DIFF
--- a/src/Akka.Analyzers.Tests/Analyzers/AK2000/ShouldNotInvokeContextMaterializerMultipleTimesAnalyzerSpecs.cs
+++ b/src/Akka.Analyzers.Tests/Analyzers/AK2000/ShouldNotInvokeContextMaterializerMultipleTimesAnalyzerSpecs.cs
@@ -118,7 +118,45 @@ public class MyActor: ReceiveActor
             .RunWith(Sink.Ignore<int>(), mat);
     }
 }
+""",
+    // Cached Context.Materializer should not trigger any warnings
 """
+using System.Linq;
+using Akka.Actor;
+using Akka.Streams;
+using Akka.Streams.Dsl;
+
+public class MyActor: ReceiveActor
+{
+    private readonly ActorMaterializer _materializer = Context.Materializer();
+    public MyActor()
+    {
+        var source1 = Source.From(Enumerable.Range(0, 100))
+            .RunWith(Sink.Ignore<int>(), _materializer);
+        var source2 = Source.From(Enumerable.Range(0, 100))
+            .RunWith(Sink.Ignore<int>(), _materializer);
+    }
+}
+""",
+    // Cached Context.Materializer should not trigger any warnings
+"""
+using System.Linq;
+using Akka.Actor;
+using Akka.Streams;
+using Akka.Streams.Dsl;
+
+public class MyActor: ReceiveActor
+{
+    private ActorMaterializer Materializer { get; } = Context.Materializer();
+    public MyActor()
+    {
+        var source1 = Source.From(Enumerable.Range(0, 100))
+            .RunWith(Sink.Ignore<int>(), Materializer);
+        var source2 = Source.From(Enumerable.Range(0, 100))
+            .RunWith(Sink.Ignore<int>(), Materializer);
+    }
+}
+""",
 	};
 	
     [Theory]
@@ -155,10 +193,33 @@ public class MyActor: ReceiveActor
 }
 """, new[]{(14, 42, 14, 64), (16, 42, 16, 64)}),
             (
+    // Context.Materializer invoked multiple times
+"""
+// 02
+using System.Linq;
+using Akka.Actor;
+using Akka.Streams;
+using Akka.Streams.Dsl;
+
+public class MyActor: ReceiveActor
+{
+    private ActorMaterializer Materializer { get; } = Context.Materializer();
+    public MyActor()
+    {
+        var source1 = Source.From(Enumerable.Range(0, 100))
+            .RunWith(Sink.Ignore<int>(), Materializer);
+        var source2 = Source.From(Enumerable.Range(0, 100))
+            .RunWith(Sink.Ignore<int>(), Context.Materializer());
+        var source3 = Source.From(Enumerable.Range(0, 100))
+            .RunWith(Sink.Ignore<int>(), Context.Materializer());
+    }
+}
+""", new[]{(15, 42, 15, 64), (17, 42, 17, 64)}),
+            (
     // Context.Materializer invoked multiple times, mixed with ActorSystem.Materializer()
     // Should not emit warning on Context.System.Materializer()
 """
-// 02
+// 03
 using System.Linq;
 using Akka.Actor;
 using Akka.Streams;
@@ -180,7 +241,7 @@ public class MyActor: ReceiveActor
             (
     // ActorMaterializerExtensions.Materializer() invoked multiple times
 """
-// 03
+// 04
 using System.Linq;
 using Akka.Actor;
 using Akka.Streams;

--- a/src/Akka.Analyzers.Tests/Analyzers/AK2000/ShouldNotInvokeContextMaterializerMultipleTimesAnalyzerSpecs.cs
+++ b/src/Akka.Analyzers.Tests/Analyzers/AK2000/ShouldNotInvokeContextMaterializerMultipleTimesAnalyzerSpecs.cs
@@ -1,0 +1,220 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="ShouldNotInvokeContextMaterializerMultipleTimesAnalyzerSpecs.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Microsoft.CodeAnalysis.Testing;
+using Verify = Akka.Analyzers.Tests.Utility.AkkaVerifier<Akka.Analyzers.ShouldNotInvokeContextMaterializerMultipleTimesAnalyzer>;
+
+namespace Akka.Analyzers.Tests.Analyzers.AK2000;
+
+public class ShouldNotInvokeContextMaterializerMultipleTimesAnalyzerSpecs
+{
+    public static readonly TheoryData<string> SuccessCases = new()
+	{
+        // Using ActorSystem.Materializer from a non-actor class should not trigger any warnings
+"""
+using System.Linq;
+using Akka.Actor;
+using Akka.Streams;
+using Akka.Streams.Dsl;
+
+public class MyClass
+{
+    public MyClass(ActorSystem system)
+    {
+        var mat1 = system.Materializer();
+        var mat2 = system.Materializer();
+
+        var source1 = Source.From(Enumerable.Range(0, 100))
+            .RunWith(Sink.Ignore<int>(), system.Materializer());
+        var source2 = Source.From(Enumerable.Range(0, 100))
+            .RunWith(Sink.Ignore<int>(), system.Materializer());
+    }
+}
+""",
+    // Using ActorSystem.Materializer from an actor class should not trigger any warnings
+"""
+using System.Linq;
+using Akka.Actor;
+using Akka.Streams;
+using Akka.Streams.Dsl;
+
+public class MyActor: ReceiveActor
+{
+    public MyActor()
+    {
+        var mat1 = Context.System.Materializer();
+        var mat2 = Context.System.Materializer();
+
+        var source1 = Source.From(Enumerable.Range(0, 100))
+            .RunWith(Sink.Ignore<int>(), Context.System.Materializer());
+        var source2 = Source.From(Enumerable.Range(0, 100))
+            .RunWith(Sink.Ignore<int>(), Context.System.Materializer());
+    }
+}
+""",
+    // Using ActorSystem.Materializer from an actor class should not trigger any warnings
+"""
+using System.Linq;
+using Akka.Actor;
+using Akka.Streams;
+using Akka.Streams.Dsl;
+
+public class MyActor: ReceiveActor
+{
+    public MyActor()
+    {
+        var system = Context.System;
+        var mat1 = system.Materializer();
+        var mat2 = system.Materializer();
+
+        var source1 = Source.From(Enumerable.Range(0, 100))
+            .RunWith(Sink.Ignore<int>(), system.Materializer());
+        var source2 = Source.From(Enumerable.Range(0, 100))
+            .RunWith(Sink.Ignore<int>(), system.Materializer());
+    }
+}
+""",
+// Using ActorMaterializerExtensions.Materializer() with ActorSystem argument from an actor class should not trigger any warnings
+"""
+using System.Linq;
+using Akka.Actor;
+using Akka.Streams;
+using Akka.Streams.Dsl;
+
+public class MyActor: ReceiveActor
+{
+    public MyActor()
+    {
+        var system = Context.System;
+        var mat1 = ActorMaterializerExtensions.Materializer(system);
+        var mat2 = ActorMaterializerExtensions.Materializer(system);
+
+        var source1 = Source.From(Enumerable.Range(0, 100))
+            .RunWith(Sink.Ignore<int>(), ActorMaterializerExtensions.Materializer(system));
+        var source2 = Source.From(Enumerable.Range(0, 100))
+            .RunWith(Sink.Ignore<int>(), ActorMaterializerExtensions.Materializer(system));
+    }
+}
+""",
+    // Cached Context.Materializer should not trigger any warnings
+"""
+using System.Linq;
+using Akka.Actor;
+using Akka.Streams;
+using Akka.Streams.Dsl;
+
+public class MyActor: ReceiveActor
+{
+    public MyActor()
+    {
+        var mat = Context.Materializer();
+
+        var source1 = Source.From(Enumerable.Range(0, 100))
+            .RunWith(Sink.Ignore<int>(), mat);
+        var source2 = Source.From(Enumerable.Range(0, 100))
+            .RunWith(Sink.Ignore<int>(), mat);
+    }
+}
+"""
+	};
+	
+    [Theory]
+    [MemberData(nameof(SuccessCases))]
+    public Task SuccessCase(string code)
+    {
+        return Verify.VerifyAnalyzer(code);
+    }
+
+    public static readonly
+        TheoryData<(string testData, (int startLine, int startColumn, int endLine, int endColumn)[] spanData)>
+        FailureCases = new()
+        {
+            (
+    // Context.Materializer invoked multiple times
+"""
+// 01
+using System.Linq;
+using Akka.Actor;
+using Akka.Streams;
+using Akka.Streams.Dsl;
+
+public class MyActor: ReceiveActor
+{
+    public MyActor()
+    {
+        var source1 = Source.From(Enumerable.Range(0, 100))
+            .RunWith(Sink.Ignore<int>(), Context.Materializer());
+        var source2 = Source.From(Enumerable.Range(0, 100))
+            .RunWith(Sink.Ignore<int>(), Context.Materializer());
+        var source3 = Source.From(Enumerable.Range(0, 100))
+            .RunWith(Sink.Ignore<int>(), Context.Materializer());
+    }
+}
+""", new[]{(14, 42, 14, 64), (16, 42, 16, 64)}),
+            (
+    // Context.Materializer invoked multiple times, mixed with ActorSystem.Materializer()
+    // Should not emit warning on Context.System.Materializer()
+"""
+// 02
+using System.Linq;
+using Akka.Actor;
+using Akka.Streams;
+using Akka.Streams.Dsl;
+
+public class MyActor: ReceiveActor
+{
+    public MyActor()
+    {
+        var source1 = Source.From(Enumerable.Range(0, 100))
+            .RunWith(Sink.Ignore<int>(), Context.Materializer());
+        var source2 = Source.From(Enumerable.Range(0, 100))
+            .RunWith(Sink.Ignore<int>(), Context.System.Materializer());
+        var source3 = Source.From(Enumerable.Range(0, 100))
+            .RunWith(Sink.Ignore<int>(), Context.Materializer());
+    }
+}
+""", new[]{(16, 42, 16, 64)}),
+            (
+    // ActorMaterializerExtensions.Materializer() invoked multiple times
+"""
+// 03
+using System.Linq;
+using Akka.Actor;
+using Akka.Streams;
+using Akka.Streams.Dsl;
+
+public class MyActor: ReceiveActor
+{
+    public MyActor()
+    {
+        var source1 = Source.From(Enumerable.Range(0, 100))
+            .RunWith(Sink.Ignore<int>(), ActorMaterializerExtensions.Materializer(Context));
+        var source2 = Source.From(Enumerable.Range(0, 100))
+            .RunWith(Sink.Ignore<int>(), Context.Materializer());
+        var source3 = Source.From(Enumerable.Range(0, 100))
+            .RunWith(Sink.Ignore<int>(), ActorMaterializerExtensions.Materializer(Context));
+    }
+}
+""", new[]{(14, 42, 14, 64), (16, 42, 16, 91)}),
+        };
+    
+    [Theory]
+    [MemberData(nameof(FailureCases))]
+    public async Task FailureCase((string testData, (int startLine, int startColumn, int endLine, int endColumn)[] spanData) d)
+    {
+        var (testData, spanData) = d;
+        var expectedDiagnostics = new DiagnosticResult[spanData.Length];
+        var currentDiagnosticIndex = 0;
+            
+        // there can be multiple violations per test case
+        foreach (var (startLine, startColumn, endLine, endColumn) in spanData)
+        {
+            expectedDiagnostics[currentDiagnosticIndex++] = Verify.Diagnostic().WithSpan(startLine, startColumn, endLine, endColumn);
+        }
+            
+        await Verify.VerifyAnalyzer(testData, expectedDiagnostics).ConfigureAwait(true);
+    }
+}

--- a/src/Akka.Analyzers.Tests/Utility/ReferenceAssembliesHelper.cs
+++ b/src/Akka.Analyzers.Tests/Utility/ReferenceAssembliesHelper.cs
@@ -34,7 +34,9 @@ internal static class ReferenceAssembliesHelper
 
         // TODO: does this bring all other transitive dependencies?
         CurrentAkka = defaultAssemblies.AddPackages(
-            ImmutableArray<PackageIdentity>.Empty.Add(new PackageIdentity("Akka.Cluster.Sharding", "1.5.15"))
+            ImmutableArray<PackageIdentity>.Empty
+                .Add(new PackageIdentity("Akka.Cluster.Sharding", "1.5.15"))
+                .Add(new PackageIdentity("Akka.Streams", "1.5.15"))
         );
     }
 }

--- a/src/Akka.Analyzers/AK2000/ShouldNotInvokeContextMaterializerMultipleTimesAnalyzer.cs
+++ b/src/Akka.Analyzers/AK2000/ShouldNotInvokeContextMaterializerMultipleTimesAnalyzer.cs
@@ -1,0 +1,110 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="ShouldNotCallContextMaterializerMultipleTimes.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Analyzers.Context;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Akka.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class ShouldNotInvokeContextMaterializerMultipleTimesAnalyzer()
+    : AkkaDiagnosticAnalyzer(RuleDescriptors.Ak2002ShouldNotCallContextMaterializerMultipleTimes)
+{
+    public override void AnalyzeCompilation(CompilationStartAnalysisContext context, AkkaContext akkaContext)
+    {
+        Guard.AssertIsNotNull(context);
+        Guard.AssertIsNotNull(akkaContext);
+
+        context.RegisterSyntaxNodeAction(ctx =>
+        {
+            // No need to check if Akka.Streams is not installed
+            if (!akkaContext.HasAkkaStreamsInstalled || 
+                akkaContext.AkkaCore.Actor.ActorBaseType is null ||
+                akkaContext.AkkaStreams.ActorMaterializerExtensions is null)
+                return;
+            
+            var classDeclaration = (ClassDeclarationSyntax)ctx.Node;
+
+            // Obtain the symbol for the class declaration.
+            var classSymbol = ctx.SemanticModel.GetDeclaredSymbol(classDeclaration);
+            if (classSymbol is null)
+                return;
+            
+            // Check if the class (or one of its base types) is Akka.Actor.ActorBase.
+            if(!classSymbol.IsDerivedOrImplements(akkaContext.AkkaCore.Actor.ActorBaseType))
+                return;
+            
+            var materializerMethod = akkaContext.AkkaStreams.ActorMaterializerExtensions.Materializer;
+            var iActorContextType = akkaContext.AkkaCore.Actor.IActorContextType;
+            var actorMaterializerExtensionsType = akkaContext.AkkaStreams.ActorMaterializerExtensionsType;
+            
+            // Search for all invocation expressions within the class declaration.
+            var materializerInvocationCount = 0;
+            var invocations = classDeclaration.DescendantNodes().OfType<InvocationExpressionSyntax>();
+            foreach (var invocation in invocations)
+            {
+                var symbolInfo = ctx.SemanticModel.GetSymbolInfo(invocation);
+                if (symbolInfo.Symbol is not IMethodSymbol methodSymbol)
+                    continue;
+
+                if (!methodSymbol.IsExtensionMethod)
+                    continue;
+                
+                var isReduced = false;
+                while (methodSymbol.ReducedFrom != null)
+                {
+                    methodSymbol = methodSymbol.ReducedFrom;
+                    isReduced = true;
+                }
+                
+                // Check if this invocation is for the extension method Materializer()
+                // defined in Akka.Streams.ActorMaterializerExtensions.
+                if (!ReferenceEquals(methodSymbol, materializerMethod))
+                    continue;
+
+                ITypeSymbol? receiverType;
+                // if it's not a reduced form, we expect that it is a static function call
+                if (!isReduced)
+                {
+                    // In static form, the first argument is the "this" parameter and the "receiver".
+                    var firstArg = invocation.ArgumentList.Arguments[0];
+                    receiverType = ctx.SemanticModel.GetTypeInfo(firstArg.Expression).Type;
+                }
+                else
+                {
+                    // in reduced type, the "receiver" is the accessed member type
+                    if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+                        continue;
+
+                    receiverType = ctx.SemanticModel.GetTypeInfo(memberAccess.Expression).Type;
+                }
+                
+                // If no receiver type could be determined, skip.
+                if (receiverType is null)
+                    continue;
+
+                // If receiver type is not IActorContext, skip.
+                // Only IActorContext (ActorCell and its brethren) is problematic
+                if (!receiverType.IsDerivedOrImplements(iActorContextType!))
+                    continue;
+                
+                materializerInvocationCount++;
+                    
+                // Report a diagnostic if more than one invocation is found.
+                if (materializerInvocationCount > 1)
+                {
+                    var diagnostic = Diagnostic.Create(
+                        RuleDescriptors.Ak2002ShouldNotCallContextMaterializerMultipleTimes,
+                        invocation.GetLocation());
+                    ctx.ReportDiagnostic(diagnostic);
+                }
+            }
+        }, SyntaxKind.ClassDeclaration);
+    }
+}

--- a/src/Akka.Analyzers/Context/AkkaContext.cs
+++ b/src/Akka.Analyzers/Context/AkkaContext.cs
@@ -8,6 +8,7 @@ using Akka.Analyzers.Context.Cluster;
 using Akka.Analyzers.Context.ClusterSharding;
 using Akka.Analyzers.Context.Core;
 using Akka.Analyzers.Context.Persistence;
+using Akka.Analyzers.Context.Streams;
 using Akka.Analyzers.Context.System;
 using Microsoft.CodeAnalysis;
 
@@ -32,6 +33,7 @@ public sealed class AkkaContext
         AkkaCluster = AkkaClusterContext.Get(compilation);
         AkkaClusterSharding = AkkaClusterShardingContext.Get(compilation);
         AkkaPersistence = AkkaPersistenceContext.Get(compilation);
+        AkkaStreams = AkkaStreamsContext.Get(compilation);
         SystemThreadingTasks = SystemThreadingTasksContext.Get(compilation);
     }
 
@@ -74,6 +76,16 @@ public sealed class AkkaContext
     /// Does the current compilation context have Akka.Persistence installed?
     /// </summary>
     public bool HasAkkaPersistenceInstalled => AkkaPersistence != EmptyPersistenceContext.Instance;
+    
+    /// <summary>
+    /// Symbol data and availability for Akka.Persistence.
+    /// </summary>
+    public IAkkaStreamsContext AkkaStreams { get; }
+    
+    /// <summary>
+    /// Does the current compilation context have Akka.Persistence installed?
+    /// </summary>
+    public bool HasAkkaStreamsInstalled => AkkaStreams != EmptyStreamsContext.Instance;
     
     public ISystemThreadingTasksContext SystemThreadingTasks { get; }
 }

--- a/src/Akka.Analyzers/Context/Streams/ActorMaterializerExtensions.cs
+++ b/src/Akka.Analyzers/Context/Streams/ActorMaterializerExtensions.cs
@@ -1,0 +1,40 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="ActorMaterializerExtensions.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Microsoft.CodeAnalysis;
+
+namespace Akka.Analyzers.Context.Streams;
+
+public interface IActorMaterializerExtensionsContext
+{
+    IMethodSymbol? Materializer { get; }
+}
+
+public sealed class EmptyActorMaterializerExtensionsContext : IActorMaterializerExtensionsContext
+{
+    public static EmptyActorMaterializerExtensionsContext Instance { get; } = new();
+    
+    private EmptyActorMaterializerExtensionsContext() { }
+    
+    public IMethodSymbol? Materializer => null;
+}
+
+
+public class ActorMaterializerExtensionsContext: IActorMaterializerExtensionsContext
+{
+    private Lazy<IMethodSymbol> _lazyMaterializer;
+    
+    private ActorMaterializerExtensionsContext(AkkaStreamsContext context)
+    {
+        _lazyMaterializer = new Lazy<IMethodSymbol>(() => (IMethodSymbol) context.ActorMaterializerExtensionsType!.GetMembers("Materializer").First());
+    }
+
+    public IMethodSymbol? Materializer => _lazyMaterializer.Value;
+    
+    public static ActorMaterializerExtensionsContext Get(AkkaStreamsContext context)
+        => new(context);
+    
+}

--- a/src/Akka.Analyzers/Context/Streams/AkkaStreamsContext.cs
+++ b/src/Akka.Analyzers/Context/Streams/AkkaStreamsContext.cs
@@ -1,0 +1,65 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="AkkaStreamsContext.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Microsoft.CodeAnalysis;
+
+namespace Akka.Analyzers.Context.Streams;
+
+public sealed class EmptyStreamsContext : IAkkaStreamsContext
+{
+    private EmptyStreamsContext()
+    {
+    }
+
+    public static EmptyStreamsContext Instance { get; } = new();
+
+    public Version Version { get; } = new();
+    public INamedTypeSymbol? ActorMaterializerExtensionsType => null;
+    
+    public IActorMaterializerExtensionsContext? ActorMaterializerExtensions => EmptyActorMaterializerExtensionsContext.Instance;
+}
+
+/// <summary>
+/// Default AkkaStreamsContext.
+/// </summary>
+/// <remarks>
+/// Used to indicate whether Akka.Streams is present inside the solution being scanned and
+/// provides access to some of the built-in type symbols that are used in analysis rules.
+/// </remarks>
+public sealed class AkkaStreamsContext : IAkkaStreamsContext
+{
+    private readonly Lazy<INamedTypeSymbol?> _lazyActorMaterializerExtensionsType;
+    
+    private readonly Lazy<IActorMaterializerExtensionsContext> _lazyActorMaterializerExtensions;
+    
+    private AkkaStreamsContext(Compilation compilation, Version version)
+    {
+        Version = version;
+        _lazyActorMaterializerExtensionsType = new Lazy<INamedTypeSymbol?>(() => StreamsSymbolFactory.AkkaStreams(compilation));
+        
+        _lazyActorMaterializerExtensions = new Lazy<IActorMaterializerExtensionsContext>(() => ActorMaterializerExtensionsContext.Get(this));
+    }
+    
+    public static IAkkaStreamsContext Get(Compilation compilation, Version? versionOverride = null)
+    {
+        // assert that compilation is not null
+        Guard.AssertIsNotNull(compilation);
+
+        var version =
+            versionOverride ??
+            compilation
+                .ReferencedAssemblyNames
+                .FirstOrDefault(a => a.Name.Equals(StreamsSymbolFactory.StreamsNamespace, StringComparison.OrdinalIgnoreCase))
+                ?.Version;
+
+        return version is null ? EmptyStreamsContext.Instance : new AkkaStreamsContext(compilation, version);
+    }
+
+    public Version Version { get; }
+    public INamedTypeSymbol? ActorMaterializerExtensionsType => _lazyActorMaterializerExtensionsType.Value;
+    
+    public IActorMaterializerExtensionsContext? ActorMaterializerExtensions => _lazyActorMaterializerExtensions.Value;
+}

--- a/src/Akka.Analyzers/Context/Streams/IAkkaStreamsContext.cs
+++ b/src/Akka.Analyzers/Context/Streams/IAkkaStreamsContext.cs
@@ -1,0 +1,18 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="IAkkaStreamsContext.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Microsoft.CodeAnalysis;
+
+namespace Akka.Analyzers.Context.Streams;
+
+public interface IAkkaStreamsContext
+{
+    Version Version { get; }
+    
+    INamedTypeSymbol? ActorMaterializerExtensionsType { get; }
+    
+    IActorMaterializerExtensionsContext? ActorMaterializerExtensions { get; }
+}

--- a/src/Akka.Analyzers/Context/Streams/StreamsSymbolFactory.cs
+++ b/src/Akka.Analyzers/Context/Streams/StreamsSymbolFactory.cs
@@ -1,0 +1,19 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="StreamsSymbolFactory.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Analyzers.Context.Core;
+using Microsoft.CodeAnalysis;
+
+namespace Akka.Analyzers.Context.Streams;
+
+public static class StreamsSymbolFactory
+{
+    public const string StreamsNamespace = AkkaCoreContext.AkkaNamespace + ".Streams";
+    
+    public static INamedTypeSymbol? AkkaStreams(Compilation compilation)
+        => Guard.AssertIsNotNull(compilation)
+            .GetTypeByMetadataName($"{StreamsNamespace}.ActorMaterializerExtensions");
+}

--- a/src/Akka.Analyzers/Utility/RuleDescriptors.cs
+++ b/src/Akka.Analyzers/Utility/RuleDescriptors.cs
@@ -109,6 +109,13 @@ public static class RuleDescriptors
         "When using any implementation of `Akka.Cluster.Sharding.IMessageExtractor`, including `HashCodeMessageExtractor`, you should not use messages " +
         "that are automatically handled by Akka.NET such as `Shard.StartEntity` and `ShardingEnvelope`.");
 
+    public static DiagnosticDescriptor Ak2002ShouldNotCallContextMaterializerMultipleTimes { get; } = Rule(
+        id: "AK2002",
+        title: "Should not invoke Context.Materializer() multiple times.", 
+        category: AnalysisCategory.ApiUsage, 
+        defaultSeverity: DiagnosticSeverity.Warning,
+        messageFormat: "Context.Materializer() should not be invoked multiple times, use a cached value instead.");
+
     #endregion
 
 }


### PR DESCRIPTION
## Changes

* Analyzer for multiple `Context.Materializer()` invocation
* also detects static `ActorMaterializerExtensions.Materializer()` calls
* rejects detection if it does not target `IActorContext` (multiple ActorSystem.Materializer() calls are allowed)