### PR TITLE
Add AK2005 - Must not use void async delegate in `Command` message handler

### DIFF
--- a/src/Akka.Analyzers.Fixes/AK2000/MustNotUseVoidAsyncDelegateInReceivePersistentActorCommandFixer.cs
+++ b/src/Akka.Analyzers.Fixes/AK2000/MustNotUseVoidAsyncDelegateInReceivePersistentActorCommandFixer.cs
@@ -1,0 +1,113 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="MustNotUseVoidAsyncDelegateInReceiveFixer.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Akka.Analyzers.Fixes;
+
+[ExportCodeFixProvider(LanguageNames.CSharp)]
+[Shared]
+public class MustNotUseVoidAsyncDelegateInReceivePersistentActorCommandFixer()
+    : BatchedCodeFixProvider(RuleDescriptors.Ak2005MustNotUseVoidAsyncDelegateInReceivePersistentActorCommand.Id)
+{
+    public const string Key_FixCommandWithVoidAsyncDelegate = "AK2005_FixCommandWithVoidAsyncDelegate";
+    
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        // 1) Get the syntax root
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return;
+
+        // 2) Find the node at the diagnostic's span
+        var diagnostic = context.Diagnostics.FirstOrDefault();
+        if (diagnostic is null)
+            return;
+        var diagnosticSpan = diagnostic.Location.SourceSpan;
+        var node = root.FindNode(diagnosticSpan);
+        
+        // 3) Find the enclosing InvocationExpressionSyntax
+        var invocation = node.FirstAncestorOrSelf<InvocationExpressionSyntax>();
+        if (invocation == null)
+            return;
+        
+        // 4) Check if any argument is an async lambda. If not, skip registering a fix.
+        var hasAsyncLambda = invocation.ArgumentList.Arguments
+            .Any(a => a.Expression is LambdaExpressionSyntax lambda && lambda.AsyncKeyword.IsKind(SyntaxKind.AsyncKeyword));
+        if (!hasAsyncLambda)
+            return;
+        
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title: "Replace Command with CommandAsync",
+                createChangedDocument: c => ReplaceCommandWithReceiveAsync(context.Document, invocation, c),
+                equivalenceKey: Key_FixCommandWithVoidAsyncDelegate),
+            diagnostic);
+    }
+
+    private static async Task<Document> ReplaceCommandWithReceiveAsync(Document document,
+        InvocationExpressionSyntax invocation, CancellationToken cancellationToken)
+    {
+        // We want to keep the same type arguments (e.g. <int>) but rename "Command" → "CommandAsync".
+        // invocation.Expression can be:
+        //   • GenericNameSyntax (e.g. Command<int>)
+        //   • MemberAccessExpressionSyntax whose .Name is a GenericNameSyntax (e.g. this.Command<int>)
+        //   • (rarely) a bare IdentifierNameSyntax
+
+        var expression = invocation.Expression;
+
+        var oldNameNode = expression switch
+        {
+            GenericNameSyntax genericName => (SimpleNameSyntax)genericName,
+            MemberAccessExpressionSyntax { Name: GenericNameSyntax memberGeneric } => memberGeneric,
+            IdentifierNameSyntax identifierName => identifierName,
+            _ => null
+        };
+        
+        if(oldNameNode is null)
+        {
+            // If we don’t find a recognizable simple name, bail out.
+            return document;
+        }
+
+        // Build a new SimpleNameSyntax with identifier "CommandAsync", preserving any type arguments.
+        SimpleNameSyntax newNameNode;
+        if (oldNameNode is GenericNameSyntax oldGeneric)
+        {
+            newNameNode = SyntaxFactory.GenericName(SyntaxFactory.Identifier("CommandAsync"), oldGeneric.TypeArgumentList);
+        }
+        else
+        {
+            newNameNode = SyntaxFactory.IdentifierName("CommandAsync");
+        }
+        
+        // If the old expression was a member‐access (e.g. this.Command<int>), replace only the Name:
+        SyntaxNode replacedExpression;
+        if (expression is MemberAccessExpressionSyntax oldMemberAccess)
+        {
+            replacedExpression = oldMemberAccess.WithName(newNameNode);
+        }
+        else
+        {
+            // Otherwise, replace the entire expression (Command<int> → CommandAsync<int>)
+            replacedExpression = newNameNode;
+        }
+
+        // Create a new InvocationExpressionSyntax with the replaced expression
+        var newInvocation = invocation.WithExpression((ExpressionSyntax)replacedExpression);
+
+        // Replace invocation in the syntax tree
+        var oldRoot = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        var newRoot = oldRoot!.ReplaceNode(invocation, newInvocation);
+
+        return document.WithSyntaxRoot(newRoot);
+    }
+}

--- a/src/Akka.Analyzers.Tests/Analyzers/AK2000/MustNotUseVoidAsyncDelegateInReceivePersistentActorCommandAnalyzerSpecs.cs
+++ b/src/Akka.Analyzers.Tests/Analyzers/AK2000/MustNotUseVoidAsyncDelegateInReceivePersistentActorCommandAnalyzerSpecs.cs
@@ -1,0 +1,292 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="MustNotUseVoidAsyncDelegateInReceivePersistentActorCommandAnalyzerSpecs.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Microsoft.CodeAnalysis.Testing;
+using Verify = Akka.Analyzers.Tests.Utility.AkkaVerifier<Akka.Analyzers.MustNotUseVoidAsyncDelegateInReceivePersistentActorCommandAnalyzer>;
+
+namespace Akka.Analyzers.Tests.Analyzers.AK2000;
+
+public class MustNotUseVoidAsyncDelegateInReceivePersistentActorCommandAnalyzerSpecs
+{
+        public static readonly TheoryData<string> SuccessCases = new()
+	{
+        // Normal ReceiveActor usage
+"""
+using Akka.Actor;
+using Akka.Persistence;
+
+public class MyActor: ReceivePersistentActor
+{
+    public MyActor(string persistenceId)
+    {
+        PersistenceId = persistenceId;
+        
+        Command<int>(msg => Sender.Tell(msg));
+        Command<int>(_ => true, msg => Sender.Tell(msg));
+        Command<int>(msg => { // Impossible to pass in void delegate, no need to analyze/fix
+            Sender.Tell(msg);
+            return true;
+        });
+        Command(typeof(int), msg => Sender.Tell(msg));
+        Command(typeof(int), _ => true, msg => Sender.Tell(msg));
+        Command(typeof(int), msg => { // Impossible to pass in void delegate, no need to analyze/fix
+            Sender.Tell(msg);
+            return true;
+        });
+        
+        Command<int>(MessageHandler);
+        Command<int>(_ => true, MessageHandler);
+        Command(typeof(int), MessageHandler);
+        Command(typeof(int), _ => true, MessageHandler);
+        
+        Command<int>(MessageHandlerBool); // Impossible to pass in void delegate, no need to analyze/fix
+        Command(typeof(int), MessageHandlerBool); // Impossible to pass in void delegate, no need to analyze/fix
+        Command(MessageHandler);
+    }
+    
+    public override string PersistenceId { get; }
+
+    private void MessageHandler(object msg) { }
+    private void MessageHandler(int msg) { }
+    private bool MessageHandlerBool(object msg) => true;
+    private bool MessageHandlerBool(int msg) => true;
+}
+""",
+	};
+	
+    [Theory]
+    [MemberData(nameof(SuccessCases))]
+    public Task SuccessCase(string code)
+    {
+        return Verify.VerifyAnalyzer(code);
+    }
+
+    public static readonly
+        TheoryData<(string testData, (int startLine, int startColumn, int endLine, int endColumn)[] spanData)>
+        ReceiveActorFailureCases = new()
+        {
+            (
+    // ReceivePersistentActor, command delegate variant 1
+"""
+// 01
+using Akka.Actor;
+using Akka.Persistence;
+using System.Threading.Tasks;
+
+public class MyActor: ReceivePersistentActor
+{
+    public MyActor(string persistenceId)
+    {
+        PersistenceId = persistenceId;
+        
+        Command<int>(async msg =>
+        {
+            await Task.Yield();
+        });
+    }
+    
+    public override string PersistenceId { get; }
+}
+""", [(12, 22, 15, 10)]),
+            (
+    // ReceivePersistentActor, command delegate variant 2
+"""
+// 02
+using Akka.Actor;
+using Akka.Persistence;
+using System.Threading.Tasks;
+
+public class MyActor: ReceivePersistentActor
+{
+    public MyActor(string persistenceId)
+    {
+        PersistenceId = persistenceId;
+        
+        Command<int>(_ => true, async msg =>
+        {
+            await Task.Yield();
+        });
+    }
+    
+    public override string PersistenceId { get; }
+}
+""", [(12, 33, 15, 10)]),
+            (
+    // ReceivePersistentActor, command delegate variant 3
+"""
+// 03
+using Akka.Actor;
+using Akka.Persistence;
+using System.Threading.Tasks;
+
+public class MyActor: ReceivePersistentActor
+{
+    public MyActor(string persistenceId)
+    {
+        PersistenceId = persistenceId;
+        
+        Command(typeof(int), async msg =>
+        {
+            await Task.Yield();
+        });
+    }
+    
+    public override string PersistenceId { get; }
+}
+""", [(12, 30, 15, 10)]),
+            (
+    // ReceivePersistentActor, command delegate variant 4
+"""
+// 04
+using Akka.Actor;
+using Akka.Persistence;
+using System.Threading.Tasks;
+
+public class MyActor: ReceivePersistentActor
+{
+    public MyActor(string persistenceId)
+    {
+        PersistenceId = persistenceId;
+        
+        Command(typeof(int), _ => true, async msg =>
+        {
+            await Task.Yield();
+        });
+    }
+    
+    public override string PersistenceId { get; }
+}
+""", [(12, 41, 15, 10)]),
+            (
+    // ReceivePersistentActor, command delegate variant 5
+"""
+// 05
+using Akka.Actor;
+using Akka.Persistence;
+using System.Threading.Tasks;
+
+public class MyActor: ReceivePersistentActor
+{
+    public MyActor(string persistenceId)
+    {
+        PersistenceId = persistenceId;
+        
+        Command<int>(MessageHandler);
+    }
+    
+    public override string PersistenceId { get; }
+
+    private async void MessageHandler(int msg) { }
+}
+""", [(12, 22, 12, 36)]),
+            (
+    // ReceivePersistentActor, command delegate variant 6
+"""
+// 06
+using Akka.Actor;
+using Akka.Persistence;
+using System.Threading.Tasks;
+
+public class MyActor: ReceivePersistentActor
+{
+    public MyActor(string persistenceId)
+    {
+        PersistenceId = persistenceId;
+        
+        Command<int>(_ => true, MessageHandler);
+    }
+    
+    public override string PersistenceId { get; }
+
+    private async void MessageHandler(int msg) { }
+}
+""", [(12, 33, 12, 47)]),
+            (
+    // ReceivePersistentActor, command delegate variant 7
+"""
+// 07
+using Akka.Actor;
+using Akka.Persistence;
+using System.Threading.Tasks;
+
+public class MyActor: ReceivePersistentActor
+{
+    public MyActor(string persistenceId)
+    {
+        PersistenceId = persistenceId;
+        
+        Command(typeof(int), MessageHandler);
+    }
+    
+    public override string PersistenceId { get; }
+
+    private async void MessageHandler(object msg) { }
+}
+""", [(12, 30, 12, 44)]),
+            (
+    // ReceivePersistentActor, command delegate variant 8
+"""
+// 08
+using Akka.Actor;
+using Akka.Persistence;
+using System.Threading.Tasks;
+
+public class MyActor: ReceivePersistentActor
+{
+    public MyActor(string persistenceId)
+    {
+        PersistenceId = persistenceId;
+        
+        Command(typeof(int), _ => true, MessageHandler);
+    }
+    
+    public override string PersistenceId { get; }
+
+    private async void MessageHandler(object msg) { }
+}
+""", [(12, 41, 12, 55)]),
+            (
+    // ReceivePersistentActor, command delegate variant 9
+"""
+// 09
+using Akka.Actor;
+using Akka.Persistence;
+using System.Threading.Tasks;
+
+public class MyActor: ReceivePersistentActor
+{
+    public MyActor(string persistenceId)
+    {
+        PersistenceId = persistenceId;
+        
+        Command(MessageHandler);
+    }
+    
+    public override string PersistenceId { get; }
+
+    private async void MessageHandler(object msg) { }
+}
+""", [(12, 17, 12, 31)]),
+            
+        };
+    
+    [Theory]
+    [MemberData(nameof(ReceiveActorFailureCases))]
+    public async Task ReceiveActorFailureCase((string testData, (int startLine, int startColumn, int endLine, int endColumn)[] spanData) d)
+    {
+        var (testData, spanData) = d;
+        var expectedDiagnostics = new DiagnosticResult[spanData.Length];
+        var currentDiagnosticIndex = 0;
+            
+        // there can be multiple violations per test case
+        foreach (var (startLine, startColumn, endLine, endColumn) in spanData)
+        {
+            expectedDiagnostics[currentDiagnosticIndex++] = Verify.Diagnostic().WithSpan(startLine, startColumn, endLine, endColumn);
+        }
+            
+        await Verify.VerifyAnalyzer(testData, expectedDiagnostics).ConfigureAwait(true);
+    }
+}

--- a/src/Akka.Analyzers.Tests/Fixes/AK2000/MustNotUseVoidAsyncDelegateInReceivePersistentActorCommandFixerSpecs.cs
+++ b/src/Akka.Analyzers.Tests/Fixes/AK2000/MustNotUseVoidAsyncDelegateInReceivePersistentActorCommandFixerSpecs.cs
@@ -1,0 +1,339 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="MustNotUseVoidAsyncDelegateInReceiveFixerSpecs.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Analyzers.Fixes;
+
+namespace Akka.Analyzers.Tests.Fixes.AK2000;
+using Verify = Akka.Analyzers.Tests.Utility.AkkaVerifier<Akka.Analyzers.MustNotUseVoidAsyncDelegateInReceivePersistentActorCommandAnalyzer>;
+
+public class MustNotUseVoidAsyncDelegateInReceivePersistentActorCommandFixerSpecs
+{
+    public static readonly
+        TheoryData<(string before, string after, (int startLine, int startColumn, int endLine, int endColumn) spanData)>
+        ReceiveActorFailureCases = new()
+        {
+            (
+    // ReceiveActor, receive delegate variant 1
+"""
+// 01
+using Akka.Actor;
+using Akka.Persistence;
+using System.Threading.Tasks;
+
+public class MyActor: ReceivePersistentActor
+{
+    public MyActor(string persistenceId)
+    {
+        PersistenceId = persistenceId;
+        
+        Command<int>(async msg =>
+        {
+            await Task.Yield();
+        });
+    }
+    
+    public override string PersistenceId { get; }
+}
+""", 
+"""
+// 01
+using Akka.Actor;
+using Akka.Persistence;
+using System.Threading.Tasks;
+
+public class MyActor: ReceivePersistentActor
+{
+    public MyActor(string persistenceId)
+    {
+        PersistenceId = persistenceId;
+        CommandAsync<int>(async msg =>
+        {
+            await Task.Yield();
+        });
+    }
+    
+    public override string PersistenceId { get; }
+}
+""", 
+(12, 22, 15, 10)),
+            (
+    // ReceiveActor, receive delegate variant 2
+"""
+// 02
+using Akka.Actor;
+using Akka.Persistence;
+using System.Threading.Tasks;
+
+public class MyActor: ReceivePersistentActor
+{
+    public MyActor(string persistenceId)
+    {
+        PersistenceId = persistenceId;
+        
+        Command<int>(_ => true, async msg =>
+        {
+            await Task.Yield();
+        });
+    }
+    
+    public override string PersistenceId { get; }
+}
+""", 
+"""
+// 02
+using Akka.Actor;
+using Akka.Persistence;
+using System.Threading.Tasks;
+
+public class MyActor: ReceivePersistentActor
+{
+    public MyActor(string persistenceId)
+    {
+        PersistenceId = persistenceId;
+        CommandAsync<int>(_ => true, async msg =>
+        {
+            await Task.Yield();
+        });
+    }
+    
+    public override string PersistenceId { get; }
+}
+""", 
+(12, 33, 15, 10)),
+            (
+    // ReceiveActor, receive delegate variant 3
+"""
+// 03
+using Akka.Actor;
+using Akka.Persistence;
+using System.Threading.Tasks;
+
+public class MyActor: ReceivePersistentActor
+{
+    public MyActor(string persistenceId)
+    {
+        PersistenceId = persistenceId;
+        
+        Command(typeof(int), async msg =>
+        {
+            await Task.Yield();
+        });
+    }
+    
+    public override string PersistenceId { get; }
+}
+""", 
+"""
+// 03
+using Akka.Actor;
+using Akka.Persistence;
+using System.Threading.Tasks;
+
+public class MyActor: ReceivePersistentActor
+{
+    public MyActor(string persistenceId)
+    {
+        PersistenceId = persistenceId;
+        CommandAsync(typeof(int), async msg =>
+        {
+            await Task.Yield();
+        });
+    }
+    
+    public override string PersistenceId { get; }
+}
+""", 
+(12, 30, 15, 10)),
+            (
+    // ReceiveActor, receive delegate variant 4
+"""
+// 04
+using Akka.Actor;
+using Akka.Persistence;
+using System.Threading.Tasks;
+
+public class MyActor: ReceivePersistentActor
+{
+    public MyActor(string persistenceId)
+    {
+        PersistenceId = persistenceId;
+        
+        Command(typeof(int), _ => true, async msg =>
+        {
+            await Task.Yield();
+        });
+    }
+    
+    public override string PersistenceId { get; }
+}
+""", 
+"""
+// 04
+using Akka.Actor;
+using Akka.Persistence;
+using System.Threading.Tasks;
+
+public class MyActor: ReceivePersistentActor
+{
+    public MyActor(string persistenceId)
+    {
+        PersistenceId = persistenceId;
+        CommandAsync(typeof(int), _ => true, async msg =>
+        {
+            await Task.Yield();
+        });
+    }
+    
+    public override string PersistenceId { get; }
+}
+""", 
+(12, 41, 15, 10)),
+
+        };
+    
+    [Theory]
+    [MemberData(nameof(ReceiveActorFailureCases))]
+    public Task RenameReceiveActorReceiveToReceiveAsync((string before, string after, (int startLine, int startColumn, int endLine, int endColumn) spanData) d)
+    {
+        var (before, after, (startLine, startColumn, endLine, endColumn)) = d;
+        var expectedDiagnostic = Verify.Diagnostic()
+            .WithSpan(startLine, startColumn, endLine, endColumn);
+
+        return Verify.VerifyCodeFix(before, after, MustNotUseVoidAsyncDelegateInReceivePersistentActorCommandFixer.Key_FixCommandWithVoidAsyncDelegate,
+            expectedDiagnostic);
+    }
+
+    public static readonly
+        TheoryData<(string data, (int startLine, int startColumn, int endLine, int endColumn) spanData)>
+        ReceiveActorIgnoredFailureCases = new()
+        {
+            (
+    // ReceiveActor, receive delegate variant 5
+"""
+// 05
+using Akka.Actor;
+using Akka.Persistence;
+
+public class MyActor: ReceivePersistentActor
+{
+    public MyActor(string persistenceId)
+    {
+        PersistenceId = persistenceId;
+        
+        Command<int>(MessageHandler);
+    }
+    
+    public override string PersistenceId { get; }
+
+    private async void MessageHandler(int msg) { }
+}
+""", 
+(11, 22, 11, 36)),
+            (
+    // ReceiveActor, receive delegate variant 6
+"""
+// 06
+using Akka.Actor;
+using Akka.Persistence;
+
+public class MyActor: ReceivePersistentActor
+{
+    public MyActor(string persistenceId)
+    {
+        PersistenceId = persistenceId;
+        
+        Command<int>(_ => true, MessageHandler);
+    }
+    
+    public override string PersistenceId { get; }
+
+    private async void MessageHandler(int msg) { }
+}
+""", 
+(11, 33, 11, 47)),
+            (
+    // ReceiveActor, receive delegate variant 7
+"""
+// 07
+using Akka.Actor;
+using Akka.Persistence;
+
+public class MyActor: ReceivePersistentActor
+{
+    public MyActor(string persistenceId)
+    {
+        PersistenceId = persistenceId;
+        
+        Command(typeof(int), _ => true, MessageHandler);
+    }
+    
+    public override string PersistenceId { get; }
+
+    private async void MessageHandler(object msg) { }
+}
+""", 
+(11, 41, 11, 55)),
+            (
+    // ReceivePersistentActor, command delegate variant 8
+"""
+// 08
+using Akka.Actor;
+using Akka.Persistence;
+using System.Threading.Tasks;
+
+public class MyActor: ReceivePersistentActor
+{
+    public MyActor(string persistenceId)
+    {
+        PersistenceId = persistenceId;
+        
+        Command(typeof(int), _ => true, MessageHandler);
+    }
+    
+    public override string PersistenceId { get; }
+
+    private async void MessageHandler(object msg) { }
+}
+""", 
+(12, 41, 12, 55)),
+            (
+    // ReceivePersistentActor, command delegate variant 9
+"""
+// 09
+using Akka.Actor;
+using Akka.Persistence;
+using System.Threading.Tasks;
+
+public class MyActor: ReceivePersistentActor
+{
+    public MyActor(string persistenceId)
+    {
+        PersistenceId = persistenceId;
+        
+        Command(MessageHandler);
+    }
+    
+    public override string PersistenceId { get; }
+
+    private async void MessageHandler(object msg) { }
+}
+""", 
+(12, 17, 12, 31)),
+
+        };    
+    [Theory]
+    [MemberData(nameof(ReceiveActorIgnoredFailureCases))]
+    public Task IgnoreComplexReceiveActorReceive((string data, (int startLine, int startColumn, int endLine, int endColumn) spanData) d)
+    {
+        var (data, (startLine, startColumn, endLine, endColumn)) = d;
+        var expectedDiagnostic = Verify.Diagnostic()
+            .WithSpan(startLine, startColumn, endLine, endColumn);
+
+        return Verify.VerifyCodeFix(data, data, MustNotUseVoidAsyncDelegateInReceivePersistentActorCommandFixer.Key_FixCommandWithVoidAsyncDelegate, 
+            [expectedDiagnostic], [expectedDiagnostic]);
+    }
+    
+}

--- a/src/Akka.Analyzers/AK2000/MustNotUseVoidAsyncDelegateInReceivePersistentActorCommandAnalyzer.cs
+++ b/src/Akka.Analyzers/AK2000/MustNotUseVoidAsyncDelegateInReceivePersistentActorCommandAnalyzer.cs
@@ -1,0 +1,71 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="MustNotUseVoidAsyncDelegateInReceiveOrCommandAnalyzer.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Analyzers.Context;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Akka.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class MustNotUseVoidAsyncDelegateInReceivePersistentActorCommandAnalyzer()
+    : AkkaDiagnosticAnalyzer(RuleDescriptors.Ak2005MustNotUseVoidAsyncDelegateInReceivePersistentActorCommand)
+{
+    public override void AnalyzeCompilation(CompilationStartAnalysisContext context, AkkaContext akkaContext)
+    {
+        Guard.AssertIsNotNull(context);
+        Guard.AssertIsNotNull(akkaContext);
+
+        context.RegisterSyntaxNodeAction(ctx =>
+        {
+            var inv = (InvocationExpressionSyntax)ctx.Node;
+            if(ctx.SemanticModel.GetSymbolInfo(inv.Expression).Symbol is not IMethodSymbol method)
+                return;
+
+            if (method.IsGenericMethod)
+                method = method.OriginalDefinition;
+            
+            var compilation = context.Compilation;
+            if (!akkaContext.AkkaPersistence.ReceivePersistentActor.Command.Any(m => SymbolEqualityComparer.Default.Equals(method, m)))
+                return;
+            
+            var actionSymbol = compilation.GetTypeByMetadataName("System.Action`1");
+            
+            var index = 0;
+            foreach (var p in method.Parameters)
+            {
+                if(ReferenceEquals(p.Type.OriginalDefinition, actionSymbol))
+                    break;
+                index++;
+            }
+            
+            if(index >= method.Parameters.Length)
+                return;
+            
+            var argExpr = inv.ArgumentList.Arguments[index].Expression;
+
+            // async lambda?
+            if (argExpr is LambdaExpressionSyntax lam && lam.AsyncKeyword.IsKind(SyntaxKind.AsyncKeyword))
+            {
+                ctx.ReportDiagnostic(Diagnostic.Create(RuleDescriptors.Ak2005MustNotUseVoidAsyncDelegateInReceivePersistentActorCommand, lam.GetLocation()));
+                return;
+            }
+            // async anonymous method?
+            if (argExpr is AnonymousMethodExpressionSyntax anon && anon.AsyncKeyword.IsKind(SyntaxKind.AsyncKeyword))
+            {
+                ctx.ReportDiagnostic(Diagnostic.Create(RuleDescriptors.Ak2005MustNotUseVoidAsyncDelegateInReceivePersistentActorCommand, anon.GetLocation()));
+                return;
+            }
+            // method‐group: look up symbol
+            if (ctx.SemanticModel.GetSymbolInfo(argExpr).Symbol is IMethodSymbol { IsAsync: true, ReturnsVoid: true })
+            {
+                ctx.ReportDiagnostic(Diagnostic.Create(RuleDescriptors.Ak2005MustNotUseVoidAsyncDelegateInReceivePersistentActorCommand, argExpr.GetLocation()));
+            }
+        }, SyntaxKind.InvocationExpression);
+    }
+}

--- a/src/Akka.Analyzers/Context/Persistence/AkkaPersistenceContext.cs
+++ b/src/Akka.Analyzers/Context/Persistence/AkkaPersistenceContext.cs
@@ -15,8 +15,10 @@ public interface IAkkaPersistenceContext
     
     INamedTypeSymbol? PersistenceType { get; }
     INamedTypeSymbol? EventsourcedType { get; }
+    INamedTypeSymbol? ReceivePersistentActorType { get; }
     
     IEventsourcedContext Eventsourced { get; }
+    IReceivePersistentActorContext ReceivePersistentActor { get; }
 }
 
 public sealed class EmptyPersistenceContext : IAkkaPersistenceContext
@@ -30,7 +32,9 @@ public sealed class EmptyPersistenceContext : IAkkaPersistenceContext
     public Version Version => new();
     public INamedTypeSymbol? PersistenceType => null;
     public INamedTypeSymbol? EventsourcedType => null;
+    public INamedTypeSymbol? ReceivePersistentActorType => null;
     public IEventsourcedContext Eventsourced => EmptyEventsourcedContext.Instance;
+    public IReceivePersistentActorContext ReceivePersistentActor => EmptyReceivePersistentActorContext.Instance;
 }
 
 public class AkkaPersistenceContext: IAkkaPersistenceContext
@@ -39,13 +43,17 @@ public class AkkaPersistenceContext: IAkkaPersistenceContext
     
     private readonly Lazy<INamedTypeSymbol?> _lazyPersistenceType;
     private readonly Lazy<INamedTypeSymbol?> _lazyEventsourcedType;
-    
+    private readonly Lazy<INamedTypeSymbol?> _lazyReceivePersistentActor;
+
     private AkkaPersistenceContext(Compilation compilation, Version version)
     {
         Version = version;
         _lazyPersistenceType = new Lazy<INamedTypeSymbol?>(() => compilation.GetTypeByMetadataName($"{PersistenceNamespace}.Persistence"));
         _lazyEventsourcedType = new Lazy<INamedTypeSymbol?>(() => compilation.GetTypeByMetadataName($"{PersistenceNamespace}.Eventsourced"));
+        _lazyReceivePersistentActor = new Lazy<INamedTypeSymbol?>(() => compilation.GetTypeByMetadataName($"{PersistenceNamespace}.ReceivePersistentActor"));
+        
         Eventsourced = EventsourcedContext.Get(this);
+        ReceivePersistentActor = ReceivePersistentActorContext.Get(this);
     }
     
     public static IAkkaPersistenceContext Get(Compilation compilation, Version? versionOverride = null)
@@ -64,5 +72,7 @@ public class AkkaPersistenceContext: IAkkaPersistenceContext
     public Version Version { get; }
     public INamedTypeSymbol? PersistenceType => _lazyPersistenceType.Value;
     public INamedTypeSymbol? EventsourcedType => _lazyEventsourcedType.Value;
+    public INamedTypeSymbol? ReceivePersistentActorType => _lazyReceivePersistentActor.Value;
     public IEventsourcedContext Eventsourced { get; }
+    public IReceivePersistentActorContext ReceivePersistentActor { get; }
 }

--- a/src/Akka.Analyzers/Context/Persistence/ReceivePersistentActorContext.cs
+++ b/src/Akka.Analyzers/Context/Persistence/ReceivePersistentActorContext.cs
@@ -1,0 +1,56 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="ReceivePersistentActorContext.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+
+namespace Akka.Analyzers.Context.Persistence;
+
+public interface IReceivePersistentActorContext
+{
+    public ImmutableArray<IMethodSymbol> CommandAsync { get; }
+    public IMethodSymbol? CommandAnyAsync { get; }
+    public ImmutableArray<IMethodSymbol> Command { get; }
+    public IMethodSymbol? CommandAny { get; }
+}
+
+public class EmptyReceivePersistentActorContext: IReceivePersistentActorContext
+{
+    public static readonly EmptyReceivePersistentActorContext Instance = new();
+    
+    public ImmutableArray<IMethodSymbol> CommandAsync => ImmutableArray<IMethodSymbol>.Empty;
+    public IMethodSymbol? CommandAnyAsync => null;
+    public ImmutableArray<IMethodSymbol> Command => ImmutableArray<IMethodSymbol>.Empty;
+    public IMethodSymbol? CommandAny => null;
+}
+
+public class ReceivePersistentActorContext: IReceivePersistentActorContext
+{
+    private readonly Lazy<ImmutableArray<IMethodSymbol>> _lazyCommandAsync;
+    private readonly Lazy<IMethodSymbol> _lazyCommandAnyAsync;
+    private readonly Lazy<ImmutableArray<IMethodSymbol>> _lazyCommand;
+    private readonly Lazy<IMethodSymbol> _lazyCommandAny;
+
+    private ReceivePersistentActorContext(AkkaPersistenceContext context)
+    {
+        _lazyCommandAsync = new Lazy<ImmutableArray<IMethodSymbol>>(() => context.ReceivePersistentActorType!
+            .GetMembers("CommandAsync").Select(m => (IMethodSymbol)m).ToImmutableArray());
+        _lazyCommandAnyAsync = new Lazy<IMethodSymbol>(() => (IMethodSymbol)context.ReceivePersistentActorType!
+            .GetMembers("CommandAnyAsync").First());
+        _lazyCommand = new Lazy<ImmutableArray<IMethodSymbol>>(() => context.ReceivePersistentActorType!
+            .GetMembers("Command").Select(m => (IMethodSymbol)m).ToImmutableArray());
+        _lazyCommandAny = new Lazy<IMethodSymbol>(() => (IMethodSymbol)context.ReceivePersistentActorType!
+            .GetMembers("CommandAny").First());
+    }
+
+    public ImmutableArray<IMethodSymbol> CommandAsync => _lazyCommandAsync.Value;
+    public IMethodSymbol? CommandAnyAsync => _lazyCommandAnyAsync.Value;
+    public ImmutableArray<IMethodSymbol> Command => _lazyCommand.Value;
+    public IMethodSymbol? CommandAny => _lazyCommandAny.Value;
+    
+    public static ReceivePersistentActorContext Get(AkkaPersistenceContext context)
+        => new(context);
+}

--- a/src/Akka.Analyzers/Utility/RuleDescriptors.cs
+++ b/src/Akka.Analyzers/Utility/RuleDescriptors.cs
@@ -129,6 +129,13 @@ public static class RuleDescriptors
         category: AnalysisCategory.ApiUsage, 
         defaultSeverity: DiagnosticSeverity.Error,
         messageFormat: "DslActor `Receive` message handler delegate must not return a `Task` or be a void async delegate. Use `ReceiveAsync` instead.");
+
+    public static DiagnosticDescriptor Ak2005MustNotUseVoidAsyncDelegateInReceivePersistentActorCommand { get; } = Rule(
+        id: "AK2005",
+        title: "ReceivePersistentActor `Command` message handler must not be a void async delegate", 
+        category: AnalysisCategory.ApiUsage, 
+        defaultSeverity: DiagnosticSeverity.Error,
+        messageFormat: "ReceivePersistentActor `Command` message handler delegate must not return a `Task` or be a void async delegate. Use `CommandAsync` instead.");
     
     #endregion
 


### PR DESCRIPTION
Fixes #121

Second part of the PR.

## Changes

> [!NOTE]
>
> The code fixer will only fix codes that can be done using simple code replacement (`Command` --> `CommandAsync`). Any complex replacement such as grouped member invocation (`Command<int>(MessageHandler)`) will be ignored by the code fixer.

## Changes

* [x] Expand AkkaContext to cover `Akka.Persistence.ReceivePersistentActor.Command`
* [x] Add AK2005 Analyzer - Must not use void async delegate in `ReceivePersistentActor.Command` message handler
* [x] Add code fix
