### PR TITLE
[AK2006] Do not handle ISystemMessage inside TellInternal

### DIFF
--- a/src/Akka.Analyzers.Tests/Analyzers/AK2000/MustNotHandleISystemMessageInsideTellInternalAnalyzerSpecs.cs
+++ b/src/Akka.Analyzers.Tests/Analyzers/AK2000/MustNotHandleISystemMessageInsideTellInternalAnalyzerSpecs.cs
@@ -1,0 +1,194 @@
+// -----------------------------------------------------------------------
+//  <copyright file="MustNotHandleISystemMessageInsideTellInternalAnalyzerSpecs.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Microsoft.CodeAnalysis.Testing;
+using Verify = Akka.Analyzers.Tests.Utility.AkkaVerifier<Akka.Analyzers.MustNotHandleISystemMessageInsideTellInternalAnalyzer>;
+
+namespace Akka.Analyzers.Tests.Analyzers.AK2000;
+
+public class MustNotHandleISystemMessageInsideTellInternalAnalyzerSpecs
+{
+    public static readonly TheoryData<string> SuccessCases = new()
+    {
+        // No usage of ISystemMessage in TellInternal
+"""
+using Akka.Actor;
+public class MyRef : ActorRefBase 
+{
+    public override ActorPath Path { get ; } = new RootActorPath(new Address("akka.tcp", "system", "127.0.0.1", 1337), "user");
+    
+    protected override void TellInternal(object message, IActorRef sender) {
+        // safe
+        var s = message.ToString();
+    }
+}
+"""
+    };
+
+    [Theory]
+    [MemberData(nameof(SuccessCases))]
+    public Task SuccessCase(string code)
+    {
+        return Verify.VerifyAnalyzer(code);
+    }
+
+    public static readonly TheoryData<(string testData, (int startLine, int startColumn, int endLine, int endColumn)[] spanData)> FailureCases = new()
+    {
+        // Explicit cast
+        (
+"""
+// 01
+using Akka.Actor;
+using Akka.Dispatch.SysMsg;
+public class MyRef : ActorRefBase 
+{
+    public override ActorPath Path { get ; } = new RootActorPath(new Address("akka.tcp", "system", "127.0.0.1", 1337), "user");
+
+    protected override void TellInternal(object message, IActorRef sender) {
+        var sysMsg = (ISystemMessage)message;
+    }
+}
+""", [(9, 22, 9, 45)]),
+        // is pattern
+        (
+"""
+// 02
+using Akka.Actor;
+using Akka.Dispatch.SysMsg;
+public class MyRef : ActorRefBase 
+{
+    public override ActorPath Path { get ; } = new RootActorPath(new Address("akka.tcp", "system", "127.0.0.1", 1337), "user");
+    
+    protected override void TellInternal(object message, IActorRef sender) {
+        if (message is ISystemMessage sysMsg) { }
+    }
+}
+""", [(9, 24, 9, 45)]),
+        // as pattern
+        (
+"""
+// 03
+using Akka.Actor;
+using Akka.Dispatch.SysMsg;
+public class MyRef : ActorRefBase 
+{
+    public override ActorPath Path { get ; } = new RootActorPath(new Address("akka.tcp", "system", "127.0.0.1", 1337), "user");
+    
+    protected override void TellInternal(object message, IActorRef sender) {
+        var sysMsg = message as ISystemMessage;
+        if (sysMsg != null) { }
+    }
+}
+""", [(9, 22, 9, 47)]),
+        // switch/case
+        (
+"""
+// 04
+using Akka.Actor;
+using Akka.Dispatch.SysMsg;
+public class MyRef : ActorRefBase 
+{
+    public override ActorPath Path { get ; } = new RootActorPath(new Address("akka.tcp", "system", "127.0.0.1", 1337), "user");
+    
+    protected override void TellInternal(object message, IActorRef sender) {
+        switch (message) {
+            case ISystemMessage sysMsg:
+                break;
+        }
+    }
+}
+""", [(10, 18, 10, 39)]),
+        // Derived type (SystemMessage)
+        (
+"""
+// 05
+using Akka.Actor;
+using Akka.Dispatch.SysMsg;
+public class MyRef : ActorRefBase 
+{
+    public override ActorPath Path { get ; } = new RootActorPath(new Address("akka.tcp", "system", "127.0.0.1", 1337), "user");
+    
+    protected override void TellInternal(object message, IActorRef sender) {
+        var sysMsg = (SystemMessage)message;
+    }
+}
+""", [(9, 22, 9, 44)]),
+        // Derived type (Escalate)
+        (
+"""
+// 06
+using Akka.Actor;
+using Akka.Dispatch.SysMsg;
+public class MyRef : ActorRefBase 
+{
+    public override ActorPath Path { get ; } = new RootActorPath(new Address("akka.tcp", "system", "127.0.0.1", 1337), "user");
+    
+    protected override void TellInternal(object message, IActorRef sender) {
+        if (message is Escalate esc) { }
+    }
+}
+""", [(9, 24, 9, 36)]),
+        // Twice inherited
+        (
+"""
+// 07
+using Akka.Actor;
+using Akka.Dispatch.SysMsg;
+public class MyRefBase : ActorRefBase 
+{
+    public override ActorPath Path { get ; } = new RootActorPath(new Address("akka.tcp", "system", "127.0.0.1", 1337), "user");
+    
+    protected override void TellInternal(object message, IActorRef sender) {
+    }
+}
+public class MyRef : MyRefBase 
+{
+    protected override void TellInternal(object message, IActorRef sender) {
+        if (message is Escalate esc) { }
+    }
+}
+""", [(14, 24, 14, 36)]),
+        // Multiple offense, should list all
+        (
+"""
+// 08
+using Akka.Actor;
+using Akka.Dispatch.SysMsg;
+public class MyRef : ActorRefBase 
+{
+    public override ActorPath Path { get ; } = new RootActorPath(new Address("akka.tcp", "system", "127.0.0.1", 1337), "user");
+    
+    protected override void TellInternal(object message, IActorRef sender) {
+        switch (message) {
+            case Stop:
+                break;
+            case Escalate:
+                break;
+            case ISystemMessage:
+                break;
+        }
+    }
+}
+""", [(10, 18, 10, 22), (12, 18, 12, 26), (14, 18, 14, 32)]),
+    };
+
+    [Theory]
+    [MemberData(nameof(FailureCases))]
+    public async Task FailureCase((string testData, (int startLine, int startColumn, int endLine, int endColumn)[] spanData) d)
+    {
+        var (testData, spanData) = d;
+        var expectedDiagnostics = new DiagnosticResult[spanData.Length];
+        var currentDiagnosticIndex = 0;
+            
+        // there can be multiple violations per test case
+        foreach (var (startLine, startColumn, endLine, endColumn) in spanData)
+        {
+            expectedDiagnostics[currentDiagnosticIndex++] = Verify.Diagnostic().WithSpan(startLine, startColumn, endLine, endColumn);
+        }
+        
+        await Verify.VerifyAnalyzer(testData, expectedDiagnostics);
+    }
+} 

--- a/src/Akka.Analyzers/AK2000/MustNotHandleISystemMessageInsideTellInternalAnalyzer.cs
+++ b/src/Akka.Analyzers/AK2000/MustNotHandleISystemMessageInsideTellInternalAnalyzer.cs
@@ -1,0 +1,92 @@
+// -----------------------------------------------------------------------
+//  <copyright file="MustNotHandleISystemMessageInsideTellInternalAnalyzer.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2024 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Analyzers.Context;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Akka.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class MustNotHandleISystemMessageInsideTellInternalAnalyzer() 
+    : AkkaDiagnosticAnalyzer(RuleDescriptors.Ak2006MustNotHandleISystemMessageInsideTellInternal)
+{
+    public override void AnalyzeCompilation(CompilationStartAnalysisContext context, AkkaContext akkaContext)
+    {
+        Guard.AssertIsNotNull(context);
+        Guard.AssertIsNotNull(akkaContext);
+
+        context.RegisterSyntaxNodeAction(AnalyzeMethod, SyntaxKind.MethodDeclaration);
+        return;
+
+        void AnalyzeMethod(SyntaxNodeAnalysisContext ctx)
+        {
+            var methodDecl = (MethodDeclarationSyntax)ctx.Node;
+            var semanticModel = ctx.SemanticModel;
+            var methodSymbol = semanticModel.GetDeclaredSymbol(methodDecl);
+            if (methodSymbol is null)
+                return;
+            
+            var akkaCore = akkaContext.AkkaCore;
+            var actorRefBaseContext = akkaCore.Actor.ActorRefBase;
+            var tellInternalSymbol = actorRefBaseContext.TellInternal;
+
+            // Check if this method overrides ActorRefBase.TellInternal
+            if (!methodSymbol.Overrides(tellInternalSymbol!))
+                return;
+            
+            var iSystemMessageType = akkaContext.AkkaCore.Dispatch.ISystemMessageType;
+            if (iSystemMessageType == null)
+                return;
+
+            // Use the existing IsDerivedOrImplements extension for type hierarchy
+            // Check all operations in the method body
+            var operation = semanticModel.GetOperation(methodDecl);
+            if (operation == null)
+                return;
+
+            foreach (var descendant in operation.DescendantsAndSelf())
+            {
+                switch (descendant)
+                {
+                    // Cast: (ISystemMessage)message
+                    case IConversionOperation conv when conv.Operand is IParameterReferenceOperation param && param.Parameter.Name == "message":
+                        if (conv.Type != null && conv.Type.IsDerivedOrImplements(iSystemMessageType))
+                        {
+                            ctx.ReportDiagnostic(Diagnostic.Create(RuleDescriptors.Ak2006MustNotHandleISystemMessageInsideTellInternal, conv.Syntax.GetLocation()));
+                        }
+                        break;
+                    // is/as: message is ISystemMessage, message as ISystemMessage
+                    case IIsTypeOperation isType when isType.ValueOperand is IParameterReferenceOperation param && param.Parameter.Name == "message":
+                        if (isType.TypeOperand != null && isType.TypeOperand.IsDerivedOrImplements(iSystemMessageType))
+                        {
+                            ctx.ReportDiagnostic(Diagnostic.Create(RuleDescriptors.Ak2006MustNotHandleISystemMessageInsideTellInternal, isType.Syntax.GetLocation()));
+                        }
+                        break;
+                    case ITypeOfOperation typeOfOp:
+                        // Not relevant
+                        break;
+                    case ITypePatternOperation typePattern:
+                        if (typePattern.MatchedType.IsDerivedOrImplements(iSystemMessageType))
+                        {
+                            ctx.ReportDiagnostic(Diagnostic.Create(RuleDescriptors.Ak2006MustNotHandleISystemMessageInsideTellInternal, typePattern.Syntax.GetLocation()));
+                        }
+                        break;
+                    // Switch/case: case ISystemMessage msg:
+                    case IDeclarationPatternOperation { MatchedType: not null } declPattern:
+                        if (declPattern.MatchedType.IsDerivedOrImplements(iSystemMessageType))
+                        {
+                            ctx.ReportDiagnostic(Diagnostic.Create(RuleDescriptors.Ak2006MustNotHandleISystemMessageInsideTellInternal, declPattern.Syntax.GetLocation()));
+                        }
+                        break;
+                }
+            }
+        }
+    }
+} 

--- a/src/Akka.Analyzers/Context/Core/Actor/ActorRefBaseContext.cs
+++ b/src/Akka.Analyzers/Context/Core/Actor/ActorRefBaseContext.cs
@@ -1,0 +1,53 @@
+// -----------------------------------------------------------------------
+//  <copyright file="ActorRefBaseContext.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2024 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Microsoft.CodeAnalysis;
+
+namespace Akka.Analyzers.Context.Core.Actor;
+
+public interface IActorRefBaseContext
+{
+    public IPropertySymbol? Path { get; }
+    public IMethodSymbol? Tell { get; }
+    public IMethodSymbol? TellInternal { get; }
+}
+
+public sealed class EmptyActorRefBaseContext : IActorRefBaseContext
+{
+    public static readonly EmptyActorRefBaseContext Instance = new();
+    private EmptyActorRefBaseContext() { }
+    public IPropertySymbol? Path => null;
+    public IMethodSymbol? Tell => null;
+    public IMethodSymbol? TellInternal => null;
+}
+
+public sealed class ActorRefBaseContext : IActorRefBaseContext
+{
+    private readonly Lazy<IPropertySymbol> _lazyPath;
+    private readonly Lazy<IMethodSymbol> _lazyTell;
+    private readonly Lazy<IMethodSymbol> _lazyTellInternal;
+
+    private ActorRefBaseContext(AkkaCoreActorContext context)
+    {
+        Guard.AssertIsNotNull(context.ActorRefBaseType);
+        _lazyPath = new Lazy<IPropertySymbol>(() => (IPropertySymbol) context.ActorRefBaseType!
+            .GetMembers("Path").First());
+        _lazyTell = new Lazy<IMethodSymbol>(() => (IMethodSymbol) context.ActorRefBaseType!
+            .GetMembers("Tell").First());
+        _lazyTellInternal = new Lazy<IMethodSymbol>(() => (IMethodSymbol) context.ActorRefBaseType!
+            .GetMembers("TellInternal").First());
+    }
+
+    public IPropertySymbol? Path => _lazyPath.Value;
+    public IMethodSymbol? Tell => _lazyTell.Value;
+    public IMethodSymbol? TellInternal => _lazyTellInternal.Value;
+
+    public static ActorRefBaseContext Get(AkkaCoreActorContext context)
+    {
+        Guard.AssertIsNotNull(context);
+        return new ActorRefBaseContext(context);
+    }
+} 

--- a/src/Akka.Analyzers/Context/Core/Actor/ActorSymbolFactory.cs
+++ b/src/Akka.Analyzers/Context/Core/Actor/ActorSymbolFactory.cs
@@ -59,4 +59,8 @@ public static class ActorSymbolFactory
     public static INamedTypeSymbol? TimerSchedulerInterface(Compilation compilation)
         => Guard.AssertIsNotNull(compilation)
             .GetTypeByMetadataName($"{AkkaActorNamespace}.ITimerScheduler");
+
+    public static INamedTypeSymbol? ActorRefBase(Compilation compilation)
+        => Guard.AssertIsNotNull(compilation)
+            .GetTypeByMetadataName($"{AkkaActorNamespace}.ActorRefBase");
 }

--- a/src/Akka.Analyzers/Context/Core/Actor/AkkaCoreActorContext.cs
+++ b/src/Akka.Analyzers/Context/Core/Actor/AkkaCoreActorContext.cs
@@ -26,6 +26,7 @@ public sealed class EmptyAkkaCoreActorContext : IAkkaCoreActorContext
     public INamedTypeSymbol? ITellSchedulerType => null;
     public INamedTypeSymbol? ActorRefsType => null;
     public INamedTypeSymbol? ITimerSchedulerType => null;
+    public INamedTypeSymbol? ActorRefBaseType => null;
 
     public IActorSystemContext ActorSystem => EmptyActorSystemContext.Instance;
     public IGracefulStopSupportContext GracefulStopSupportSupport => EmptyGracefulStopSupportContext.Instance;
@@ -39,6 +40,7 @@ public sealed class EmptyAkkaCoreActorContext : IAkkaCoreActorContext
     public IActorRefsContext ActorRefs => EmptyActorRefsContext.Empty;
     public ITimerSchedulerContext ITimerScheduler => EmptyTimerSchedulerContext.Instance;
     public IDslContext Dsl => EmptyDslContext.Instance;
+    public IActorRefBaseContext ActorRefBase => EmptyActorRefBaseContext.Instance;
 }
 
 public sealed class AkkaCoreActorContext : IAkkaCoreActorContext
@@ -55,6 +57,7 @@ public sealed class AkkaCoreActorContext : IAkkaCoreActorContext
     private readonly Lazy<INamedTypeSymbol?> _lazyTellSchedulerInterface;
     private readonly Lazy<INamedTypeSymbol?> _lazyActorRefsType;
     private readonly Lazy<INamedTypeSymbol?> _lazyITimerSchedulerType;
+    private readonly Lazy<INamedTypeSymbol?> _lazyActorRefBaseType;
     
     private readonly Lazy<IActorSystemContext> _lazyActorSystem;
     private readonly Lazy<IActorRefFactoryExtensionsContext> _lazyActorRefFactoryExtensions;
@@ -79,6 +82,7 @@ public sealed class AkkaCoreActorContext : IAkkaCoreActorContext
         _lazyTellSchedulerInterface = new Lazy<INamedTypeSymbol?>(() => ActorSymbolFactory.TellSchedulerInterface(compilation));
         _lazyActorRefsType = new Lazy<INamedTypeSymbol?>(() => ActorSymbolFactory.ActorRefs(compilation));
         _lazyITimerSchedulerType = new Lazy<INamedTypeSymbol?>(() => ActorSymbolFactory.TimerSchedulerInterface(compilation));
+        _lazyActorRefBaseType = new Lazy<INamedTypeSymbol?>(() => ActorSymbolFactory.ActorRefBase(compilation));
 
         _lazyActorSystem = new Lazy<IActorSystemContext>(() => ActorSystemContext.Get(this));
         _lazyActorRefFactoryExtensions = new Lazy<IActorRefFactoryExtensionsContext>(() => ActorRefFactoryExtensionsContext.Get(this));
@@ -92,6 +96,7 @@ public sealed class AkkaCoreActorContext : IAkkaCoreActorContext
         ActorRefs = ActorRefsContext.Get(this);
         ITimerScheduler = TimerSchedulerContext.Get(this);
         Dsl = DslContext.Get(compilation);
+        ActorRefBase = ActorRefBaseContext.Get(this);
     }
 
     public INamedTypeSymbol? ActorBaseType => _lazyActorBaseType.Value;
@@ -106,6 +111,7 @@ public sealed class AkkaCoreActorContext : IAkkaCoreActorContext
     public INamedTypeSymbol? ActorRefsType => _lazyActorRefsType.Value;
     public INamedTypeSymbol? GracefulStopSupportType => _lazyGracefulStopSupportType.Value;
     public INamedTypeSymbol? ITimerSchedulerType => _lazyITimerSchedulerType.Value;
+    public INamedTypeSymbol? ActorRefBaseType => _lazyActorRefBaseType.Value;
     
     public IActorSystemContext ActorSystem => _lazyActorSystem.Value;
     public IGracefulStopSupportContext GracefulStopSupportSupport => _lazyGracefulStopSupport.Value;
@@ -119,6 +125,7 @@ public sealed class AkkaCoreActorContext : IAkkaCoreActorContext
     public IActorRefsContext ActorRefs { get; }
     public ITimerSchedulerContext ITimerScheduler { get; }
     public IDslContext Dsl { get; }
+    public IActorRefBaseContext ActorRefBase { get; }
 
     public static IAkkaCoreActorContext Get(Compilation compilation)
         => new AkkaCoreActorContext(compilation);

--- a/src/Akka.Analyzers/Context/Core/Actor/IAkkaCoreActorContext.cs
+++ b/src/Akka.Analyzers/Context/Core/Actor/IAkkaCoreActorContext.cs
@@ -25,6 +25,7 @@ public interface IAkkaCoreActorContext
     public INamedTypeSymbol? ITellSchedulerType { get; }
     public INamedTypeSymbol? ActorRefsType { get; }
     public INamedTypeSymbol? ITimerSchedulerType { get; } 
+    public INamedTypeSymbol? ActorRefBaseType { get; }
     
     public IActorSystemContext ActorSystem { get; }
     public IGracefulStopSupportContext GracefulStopSupportSupport { get; }
@@ -38,4 +39,5 @@ public interface IAkkaCoreActorContext
     public IActorRefsContext ActorRefs { get; }
     public ITimerSchedulerContext ITimerScheduler { get; }
     public IDslContext Dsl { get; }
+    public IActorRefBaseContext ActorRefBase { get; }
 }

--- a/src/Akka.Analyzers/Context/Core/AkkaCoreContext.cs
+++ b/src/Akka.Analyzers/Context/Core/AkkaCoreContext.cs
@@ -5,6 +5,7 @@
 // -----------------------------------------------------------------------
 
 using Akka.Analyzers.Context.Core.Actor;
+using Akka.Analyzers.Context.Core.Dispatch;
 using Microsoft.CodeAnalysis;
 
 namespace Akka.Analyzers.Context.Core;
@@ -22,6 +23,7 @@ public sealed class EmptyCoreContext : IAkkaCoreContext
 
     public Version Version { get; } = new();
     public IAkkaCoreActorContext Actor => EmptyAkkaCoreActorContext.Instance;
+    public IAkkaCoreDispatchContext Dispatch => EmptyAkkaCoreDispatchContext.Instance;
 }
 
 /// <summary>
@@ -39,11 +41,13 @@ public sealed class AkkaCoreContext : IAkkaCoreContext
     {
         Version = version;
         Actor = AkkaCoreActorContext.Get(compilation);
+        Dispatch = AkkaCoreDispatchContext.Get(compilation);
     }
 
     /// <inheritdoc />
     public Version Version { get; }
     public IAkkaCoreActorContext Actor { get; }
+    public IAkkaCoreDispatchContext Dispatch { get; }
 
     public static IAkkaCoreContext Get(
         Compilation compilation,

--- a/src/Akka.Analyzers/Context/Core/Dispatch/AkkaCoreDispatchContext.cs
+++ b/src/Akka.Analyzers/Context/Core/Dispatch/AkkaCoreDispatchContext.cs
@@ -1,0 +1,32 @@
+// -----------------------------------------------------------------------
+//  <copyright file="AkkaCoreDispatchContext.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2024 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Microsoft.CodeAnalysis;
+
+namespace Akka.Analyzers.Context.Core.Dispatch;
+
+public sealed class EmptyAkkaCoreDispatchContext : IAkkaCoreDispatchContext
+{
+    private EmptyAkkaCoreDispatchContext() { }
+    public static EmptyAkkaCoreDispatchContext Instance { get; } = new();
+    public INamedTypeSymbol? ISystemMessageType => null;
+}
+
+public sealed class AkkaCoreDispatchContext : IAkkaCoreDispatchContext
+{
+    private readonly Lazy<INamedTypeSymbol?> _lazyISystemMessageType;
+
+    private AkkaCoreDispatchContext(Compilation compilation)
+    {
+        _lazyISystemMessageType = new Lazy<INamedTypeSymbol?>(() =>
+            compilation.GetTypeByMetadataName("Akka.Dispatch.SysMsg.ISystemMessage"));
+    }
+
+    public INamedTypeSymbol? ISystemMessageType => _lazyISystemMessageType.Value;
+
+    public static IAkkaCoreDispatchContext Get(Compilation compilation)
+        => new AkkaCoreDispatchContext(compilation);
+} 

--- a/src/Akka.Analyzers/Context/Core/Dispatch/IAkkaCoreDispatchContext.cs
+++ b/src/Akka.Analyzers/Context/Core/Dispatch/IAkkaCoreDispatchContext.cs
@@ -1,0 +1,16 @@
+// -----------------------------------------------------------------------
+//  <copyright file="IAkkaCoreDispatchContext.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2024 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Microsoft.CodeAnalysis;
+
+namespace Akka.Analyzers.Context.Core.Dispatch;
+
+// ReSharper disable InconsistentNaming
+public interface IAkkaCoreDispatchContext
+{
+    // Only focus on the ISystemMessage interface type for now
+    public INamedTypeSymbol? ISystemMessageType { get; }
+} 

--- a/src/Akka.Analyzers/Context/Core/IAkkaCoreContext.cs
+++ b/src/Akka.Analyzers/Context/Core/IAkkaCoreContext.cs
@@ -5,6 +5,7 @@
 // -----------------------------------------------------------------------
 
 using Akka.Analyzers.Context.Core.Actor;
+using Akka.Analyzers.Context.Core.Dispatch;
 
 namespace Akka.Analyzers.Context.Core;
 
@@ -19,4 +20,5 @@ public interface IAkkaCoreContext
     public Version Version { get; }
 
     public IAkkaCoreActorContext Actor { get; }
+    public IAkkaCoreDispatchContext Dispatch { get; }
 }

--- a/src/Akka.Analyzers/Utility/CodeAnalysisExtensions.cs
+++ b/src/Akka.Analyzers/Utility/CodeAnalysisExtensions.cs
@@ -196,6 +196,18 @@ internal static class CodeAnalysisExtensions
     }
     
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool Overrides(this IMethodSymbol methodSymbol, IMethodSymbol refMethod)
+    {
+        if (!methodSymbol.IsOverride)
+            return false;
+        
+        while (methodSymbol.OverriddenMethod != null)
+            methodSymbol = methodSymbol.OverriddenMethod;
+
+        return ReferenceEquals(methodSymbol, refMethod);
+    }
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool OverridesAny(this IMethodSymbol methodSymbol, IReadOnlyCollection<IMethodSymbol> refMethods)
     {
         if (!methodSymbol.IsOverride)

--- a/src/Akka.Analyzers/Utility/RuleDescriptors.cs
+++ b/src/Akka.Analyzers/Utility/RuleDescriptors.cs
@@ -137,6 +137,13 @@ public static class RuleDescriptors
         defaultSeverity: DiagnosticSeverity.Error,
         messageFormat: "ReceivePersistentActor `Command` message handler delegate must not return a `Task` or be a void async delegate. Use `CommandAsync` instead.");
     
+    public static DiagnosticDescriptor Ak2006MustNotHandleISystemMessageInsideTellInternal { get; } = Rule(
+        id: "AK2006",
+        title: "Must not handle `ISystemMessage` inside `ActorRefBase.TellInternal`.", 
+        category: AnalysisCategory.ApiUsage, 
+        defaultSeverity: DiagnosticSeverity.Error,
+        messageFormat: "`ISystemMessage` must not be handled inside `ActorRefBase.TellInternal()`, it must be handled inside `InternalActorRefBase.SendSystemMessage()`.");
+    
     #endregion
 
 }


### PR DESCRIPTION
Fixes #116

## Changes

* Add AK2006 rule: "Must not handle `ISystemMessage` inside `ActorRefBase.TellInternal`."
* Add unit tests
